### PR TITLE
Fixed random contest picker related issue

### DIFF
--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -26,6 +26,7 @@ const ContestPage = () => {
 
   const [contestList, setContestList] = useState({ contests: [], error: "" });
   const [randomContest, setRandomContest] = useState(-1);
+  const [isRandomClicked, setIsRandomClicked] = useState(false);
 
   interface filt {
     perPage: number;
@@ -159,6 +160,8 @@ const ContestPage = () => {
           name="Contest"
           setRandom={(num) => {
             setRandomContest(num);
+            setIsRandomClicked(true);
+            setFilter({ ...filter, perPage: 1 }); // Set page size to 1 when random contest is selected
           }}
           theme={state.appState.theme}
         >
@@ -244,7 +247,7 @@ const ContestPage = () => {
         </div>
         <div
           className={"ps-3 pe-3 pt-3 pb-3 " + state.appState.theme.bg}
-        // style={{ height: "calc(100vh - 175px)" }}
+          // style={{ height: "calc(100vh - 175px)" }}
         >
           <div className={"h-100 m-0 pb-2 " + state.appState.theme.bg}>
             {state.problemList.loading ? (
@@ -287,18 +290,20 @@ const ContestPage = () => {
           </div>
         </div>
       </div>
-      <footer className={"pt-2 " + state.appState.theme.bg}>
-        <Pagination
-          pageSelected={(e) => setSelected(e)}
-          perPage={filter.perPage}
-          selected={selected}
-          theme={state.appState.theme}
-          totalCount={contestList.contests.length}
-          pageSize={(e) => {
-            setFilter({ ...filter, perPage: e });
-          }}
-        />
-      </footer>
+      {!isRandomClicked && (
+        <footer className={"pt-2 " + state.appState.theme.bg}>
+          <Pagination
+            pageSelected={(e) => setSelected(e)}
+            perPage={filter.perPage}
+            selected={selected}
+            theme={state.appState.theme}
+            totalCount={contestList.contests.length}
+            pageSize={(e) => {
+              setFilter({ ...filter, perPage: e });
+            }}
+          />
+        </footer>
+      )}
     </>
   );
 };

--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -161,7 +161,6 @@ const ContestPage = () => {
           setRandom={(num) => {
             setRandomContest(num);
             setIsRandomClicked(true);
-            setFilter({ ...filter, perPage: 1 }); // Set page size to 1 when random contest is selected
           }}
           theme={state.appState.theme}
         >


### PR DESCRIPTION
![image](https://github.com/mbashem/cftracker/assets/137029816/9de6d7a9-2572-4740-9cda-ac9345e6aa3f)
previously even, the random picker will give only one contest at a time, we can navigate through the other pages too, but now i hided the navigation if the random contest picker is selected .

I mentioned the same in https://github.com/mbashem/cftracker/issues/140 (just fixed pagination, couldn't resolve the results showing as it will change the count of rendering contest count if all contest is selected)