### PR TITLE
Fixed random problem picker related issue

### DIFF
--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -26,6 +26,7 @@ const ContestPage = () => {
 
   const [contestList, setContestList] = useState({ contests: [], error: "" });
   const [randomContest, setRandomContest] = useState(-1);
+  const [isRandomClicked, setIsRandomClicked] = useState(false);
 
   interface filt {
     perPage: number;
@@ -159,6 +160,8 @@ const ContestPage = () => {
           name="Contest"
           setRandom={(num) => {
             setRandomContest(num);
+            setIsRandomClicked(true);
+            setFilter({ ...filter, perPage: 1 }); // Set page size to 1 when random contest is selected
           }}
           theme={state.appState.theme}
         >
@@ -244,7 +247,7 @@ const ContestPage = () => {
         </div>
         <div
           className={"ps-3 pe-3 pt-3 pb-3 " + state.appState.theme.bg}
-        // style={{ height: "calc(100vh - 175px)" }}
+          // style={{ height: "calc(100vh - 175px)" }}
         >
           <div className={"h-100 m-0 pb-2 " + state.appState.theme.bg}>
             {state.problemList.loading ? (
@@ -287,18 +290,20 @@ const ContestPage = () => {
           </div>
         </div>
       </div>
-      <footer className={"pt-2 " + state.appState.theme.bg}>
-        <Pagination
-          pageSelected={(e) => setSelected(e)}
-          perPage={filter.perPage}
-          selected={selected}
-          theme={state.appState.theme}
-          totalCount={contestList.contests.length}
-          pageSize={(e) => {
-            setFilter({ ...filter, perPage: e });
-          }}
-        />
-      </footer>
+      {!isRandomClicked && (
+        <footer className={"pt-2 " + state.appState.theme.bg}>
+          <Pagination
+            pageSelected={(e) => setSelected(e)}
+            perPage={filter.perPage}
+            selected={selected}
+            theme={state.appState.theme}
+            totalCount={contestList.contests.length}
+            pageSize={(e) => {
+              setFilter({ ...filter, perPage: e });
+            }}
+          />
+        </footer>
+      )}
     </>
   );
 };

--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -161,7 +161,6 @@ const ContestPage = () => {
           setRandom={(num) => {
             setRandomContest(num);
             setIsRandomClicked(true);
-            setFilter({ ...filter, perPage: 1 }); // Set page size to 1 when random contest is selected
           }}
           theme={state.appState.theme}
         >

--- a/src/components/problem/ProblemPage.tsx
+++ b/src/components/problem/ProblemPage.tsx
@@ -82,6 +82,7 @@ const ProblemPage = () => {
   const [filterState, setFilterState] = useState(initFilterState);
   const [solved, setSolved] = useState(new Set<string>());
   const [attempted, setAttempted] = useState(new Set<string>());
+  const [isRandomClicked, setIsRandomClicked] = useState(false);
 
   const filterProblem = (problem: Problem) => {
     let containTags = false;
@@ -220,6 +221,7 @@ const ProblemPage = () => {
           selected={selected}
           setRandom={(num) => {
             setRandomProblem(num);
+            setIsRandomClicked(true);
           }}
           theme={state.appState.theme}
         >
@@ -359,7 +361,7 @@ const ProblemPage = () => {
           </div>
         </div>
       </div>
-
+    {!isRandomClicked && (
       <footer className={"pt-2 " + state.appState.theme.bg}>
         <Pagination
           totalCount={problemList.problems.length}
@@ -372,6 +374,7 @@ const ProblemPage = () => {
           }}
         />
       </footer>
+    )}
     </>
   );
 };


### PR DESCRIPTION
![image](https://github.com/mbashem/cftracker/assets/137029816/52b4736c-a1d1-42c0-b4bf-4b897f1a2459)
previously even, the random picker will give only one problem at a time, we can navigate through the other pages too, but now i hided the navigation if the random problem picker is selected .

I mentioned the same in https://github.com/mbashem/cftracker/issues/139 (just fixed pagination, couldn't resolve the results showing as it will change the count of rendering problem count if all contest is selected)