### PR TITLE
Update codebase and add few small features.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,135 @@
+# Contributing to CFTracker
+
+Thanks for helping modernize CFTracker. The project has useful bones and some legacy corners, so small, well-scoped improvements are especially valuable.
+
+## Before You Start
+
+1. Read [README.md](./README.md) for project setup.
+2. Read [DEVELOPMENT.md](./DEVELOPMENT.md) for architecture and development workflow.
+3. Open an issue describing the change you want to make.
+4. Wait for maintainer approval on that issue before starting implementation.
+5. Check existing patterns near the code you plan to change.
+6. Run and test the project locally before pushing your branch.
+
+Please do not open a pull request for new work unless the related issue has been approved by the maintainer first. Unapproved pull requests may be closed so the project can keep scope and direction under control.
+
+## Branches
+
+Create a focused branch for each change:
+
+```bash
+git checkout -b feature/problem-page-cleanup
+```
+
+Use a descriptive branch name, such as:
+
+- `feature/list-export`
+- `fix/problem-filter-reset`
+- `refactor/contest-page-views`
+- `docs/backend-setup`
+
+## Scope
+
+Keep pull requests focused. A good PR usually does one of these:
+
+- Adds one feature.
+- Fixes one bug.
+- Refactors one page or module.
+- Updates one documentation area.
+
+Avoid mixing broad formatting, unrelated cleanup, and feature work in the same PR.
+
+## Frontend Guidelines
+
+- Follow the current page pattern: business logic belongs in a page hook, view composition belongs in the page component.
+- Prefer existing shared components under `src/components/common`.
+- Keep feature-specific views in the feature folder, for example `src/components/problem/problem-list`.
+- Use existing domain types from `src/types/`.
+- Use helpers from `src/util/` instead of reimplementing URLs, storage, sorting, or route logic.
+- Keep persisted state intentional. Use local storage only for preferences that should survive reloads.
+- Keep URL query params for state that should be shareable or restorable by link.
+
+## Backend Guidelines
+
+- Keep backend changes inside `backend/` unless frontend API wiring is also required.
+- Add new authenticated routes under `/api`.
+- Reuse the existing Gin route grouping and repository patterns.
+- Keep secrets in `.env`; never commit real credentials.
+
+## Documentation Guidelines
+
+Update docs when behavior, setup, environment variables, routes, or development workflow changes.
+
+Use:
+
+- [README.md](./README.md) for project overview and setup.
+- [DEVELOPMENT.md](./DEVELOPMENT.md) for developer workflow and architecture.
+- [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution rules and PR expectations.
+
+## Validation
+
+Run the app locally and manually test the affected flow before pushing your branch.
+
+Run the production build before opening a PR:
+
+```bash
+npm run build
+```
+
+Run lint when your change touches TypeScript or React code:
+
+```bash
+npm run lint
+```
+
+For backend changes:
+
+```bash
+cd backend
+make test
+```
+
+`npx tsc -b` is not currently a clean required gate because of legacy project issues. If you fix those issues, update [DEVELOPMENT.md](./DEVELOPMENT.md) and this guide.
+
+## Commit Messages
+
+Use clear, imperative commit messages:
+
+```text
+Refactor problem page into hook and views
+Fix contest category multiselect reset
+Document backend setup
+```
+
+## Pull Request Checklist
+
+Before opening a PR, confirm:
+
+- A related issue exists and has maintainer approval.
+- The change is scoped and described clearly.
+- The affected flow was run and tested locally before pushing.
+- `npm run build` passes, or the PR explains why it could not be run.
+- Backend tests pass for backend changes, or the PR explains why they could not be run.
+- New or changed behavior is documented.
+- User-facing behavior changes include screenshots or notes when helpful.
+- The PR does not include unrelated generated files, logs, local env files, or credentials.
+
+## Reporting Bugs
+
+Include:
+
+- What you expected.
+- What happened.
+- Steps to reproduce.
+- Browser and OS if the issue is UI-related.
+- Codeforces handles or contest/problem IDs involved, when relevant.
+- Console or network errors, if available.
+
+## Proposing Refactors
+
+Refactors are welcome when they improve readability or reduce duplicated logic. Keep them reviewable:
+
+- Explain the boundary you are moving.
+- Preserve existing behavior unless the PR explicitly says otherwise.
+- Prefer one page, hook, or module per refactor PR.
+- Include validation notes.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -111,6 +111,8 @@ Local debug mode is based on Vite's development flag, so `npm run dev` uses the 
 
 User submissions are fetched for comma-separated Codeforces handles entered in the navbar. Submission status is converted into solved, attempted, and unsolved states in feature hooks.
 
+In local debug mode, identical Codeforces API URLs reuse a browser-local response for 30 minutes. Simultaneous requests for the same URL also share one in-flight request. Production requests are not cached by this helper.
+
 Several filters are saved in browser local storage through `src/util/StorageService.ts`. Search text and list-add mode use URL query params from `src/util/constants.ts`.
 
 ## Environment Variables

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,280 @@
+# CFTracker Development Guide
+
+This guide explains how to set up the project locally, understand the code layout, and develop new features safely.
+
+## Quick Start
+
+```bash
+git clone https://github.com/mbashem/cftracker.git
+cd cftracker
+npm install
+npm run dev
+```
+
+Open the local URL printed by Vite in the terminal.
+
+The frontend can run without the backend. Backend-backed features, such as GitHub login and saved lists, are optional.
+
+## Repository Shape
+
+```text
+src/
+  components/          Page-level features and shared UI components
+  data/                Redux store, reducers, hooks, RTK Query APIs, data fetch actions
+  hooks/               App-level reusable hooks
+  types/               Codeforces and CFTracker domain models
+  util/                Routing, storage, sorting, theme, URLs, general helpers
+backend/               Optional Go API for auth, profile, and lists
+scripts/               Codeforces snapshot refresh scripts
+manage-contests/       Personal admin utility for contest/problem management
+```
+
+## Frontend Architecture
+
+The app is a React/Vite SPA. Routes are registered in `src/App.tsx`, and route constants live in `src/util/route/path.ts`.
+
+The navigation component, `src/components/Menu.tsx`, performs the initial data loads:
+
+- Codeforces problemset data from `src/data/saved_api/problems_data.ts` in local debug mode, or from the public API outside debug mode.
+- Contest snapshot data from `src/data/saved_api/contests_data.ts`.
+- Shared-problem data from `src/data/saved_api/related.ts`.
+
+Redux Toolkit state is configured in `src/data/store.ts`. Feature state is split across reducers in `src/data/reducers/`.
+
+Use these local patterns when adding or refactoring pages:
+
+- Put page orchestration and business logic in a page hook, for example `useContestPage` or `useProblemPage`.
+- Keep page components focused on composition.
+- Move repeated view pieces into feature subfolders, for example `contest/contest-list` and `problem/problem-list`.
+- Prefer existing shared UI controls from `src/components/common`.
+- Keep filter and view state persistent only when that behavior already exists or is explicitly desired.
+
+## Persistence Helpers
+
+Use `usePersistentState` for page-local state that must survive reloads. It delegates reads and writes to `StorageService`.
+
+Persisted storage key names belong under `StorageService.Keys`. Do not define storage key strings inside page hooks.
+
+`StorageService` owns the low-level storage handlers:
+
+- `getObject` / `saveObject`
+- `getSet` / `saveSet`
+- `getMap` / `saveMap`
+
+## Main Feature Areas
+
+### Contests
+
+Location: `src/components/contest/`
+
+`ContestPage.tsx` composes filters, category selection, list rendering, and pagination. `useContestPage.ts` owns filtering, category state, participant type filters, solve status filters, pagination, and submission-derived contest state.
+
+Contest table views live in `src/components/contest/contest-list/`.
+
+### Problems
+
+Location: `src/components/problem/`
+
+`ProblemPage.tsx` composes the toolbar, filter modal, problem table, and pagination. `useProblemPage.ts` owns problem filtering, sorting, solve status, tag filters, pagination, random selection, URL search sync, and list-add mode.
+
+Problem table views live in `src/components/problem/problem-list/`.
+
+### Stats
+
+Location: `src/components/stats/`
+
+`useStatPage.ts` groups loaded submissions by verdict and rating. Chart components live in `src/components/stats/charts/`.
+
+### Lists
+
+Location: `src/components/list/`
+
+Lists require the optional backend. The frontend uses RTK Query APIs from `src/data/queries/listQuery.ts`. Authenticated routes are guarded by `src/util/route/AuthGuard.ts`.
+
+### Manage Contests
+
+Location: `manage-contests/`
+
+`manage-contests` is a separate personal admin tool for maintaining contest/problem/shared-contest data. It is not part of the public CFTracker user-facing app and should be treated as an operator utility. It can run destructive admin actions, so do not expose it as a public deployment.
+
+## Data Flow
+
+Codeforces problemset data is loaded from `src/data/saved_api/problems_data.ts` while running Vite locally. Outside local debug mode, it is fetched live from:
+
+```text
+https://codeforces.com/api/problemset.problems?lang=en
+```
+
+Contest data is loaded from a checked-in generated snapshot. Refresh scripts live in `scripts/`.
+
+Local debug mode is based on Vite's development flag, so `npm run dev` uses the saved problem snapshot and production builds use the live API.
+
+User submissions are fetched for comma-separated Codeforces handles entered in the navbar. Submission status is converted into solved, attempted, and unsolved states in feature hooks.
+
+Several filters are saved in browser local storage through `src/util/StorageService.ts`. Search text and list-add mode use URL query params from `src/util/constants.ts`.
+
+## Environment Variables
+
+Frontend-only development does not need a `.env` file.
+
+### Root Frontend `.env`
+
+Create root `.env` only when enabling backend-backed features in the Vite app:
+
+```bash
+VITE_BACKEND_API_URL=http://localhost:8080/api
+VITE_IS_BACKEND_AVAILABLE=true
+VITE_GITHUB_OAUTH_CLIENT_ID=your_github_oauth_client_id
+VITE_GITHUB_OAUTH_REDIRECT_URI=http://localhost:5173/callback/auth-gh
+```
+
+Leave `VITE_IS_BACKEND_AVAILABLE` unset for frontend-only mode. Backend UI is enabled only when it is set to the literal value `true`.
+
+Root frontend envs currently read by the app:
+
+| Variable | Required | Used for |
+| --- | --- | --- |
+| `VITE_BACKEND_API_URL` | Only with backend features | RTK Query base URL. Use `http://localhost:8080/api` locally. |
+| `VITE_IS_BACKEND_AVAILABLE` | Only with backend features | Shows backend-only nav/auth/list UI only when set to `true`. |
+| `VITE_GITHUB_OAUTH_CLIENT_ID` | Only with GitHub login | GitHub OAuth login link. |
+| `VITE_GITHUB_OAUTH_REDIRECT_URI` | Only with GitHub login | GitHub OAuth redirect target, usually `http://localhost:5173/callback/auth-gh`. |
+| `VITE_BACKEND_NOT_AVAILBLE_MESSAGE` | Optional | Currently exported from `src/util/env.ts`; not central to the main flow. |
+
+### Backend `.env`
+
+Create `backend/.env` when running the Go API:
+
+```bash
+GITHUB_CLIENT_ID=your_github_oauth_client_id
+GITHUB_CLIENT_SECRET=your_github_oauth_client_secret
+GITHUB_REDIRECT_URL=http://localhost:5173/callback/auth-gh
+DATABASE_URL=postgres://postgres:postgrespw@localhost:5432/cftracker?sslmode=disable
+JWT_SECRET=replace_with_a_long_random_string
+```
+
+Backend envs:
+
+| Variable | Required | Used for |
+| --- | --- | --- |
+| `GITHUB_CLIENT_ID` | Yes | GitHub OAuth app client ID. |
+| `GITHUB_CLIENT_SECRET` | Yes | GitHub OAuth app client secret. |
+| `GITHUB_REDIRECT_URL` | Yes | GitHub OAuth callback URL. |
+| `DATABASE_URL` | Yes | PostgreSQL connection string. |
+| `JWT_SECRET` | Yes | Signing/verifying app JWTs. |
+
+### `manage-contests/.env`
+
+Create `manage-contests/.env` when running the admin tool:
+
+```bash
+DATABASE_URL=postgres://postgres:postgrespw@localhost:5432/cftracker_manage?sslmode=disable
+CF_API_KEY=your_codeforces_api_key
+CF_API_SECRET=your_codeforces_api_secret
+```
+
+Admin tool envs:
+
+| Variable | Required | Used for |
+| --- | --- | --- |
+| `DATABASE_URL` | Yes | Prisma/PostgreSQL connection string for admin data. |
+| `CF_API_KEY` | Only for authenticated Codeforces API calls | Codeforces API key. |
+| `CF_API_SECRET` | Only for authenticated Codeforces API calls | Codeforces API secret used to sign requests. |
+
+## Optional Backend
+
+The backend is a Go/Gin API under `backend/`. It provides GitHub OAuth, user profile endpoints, and saved problem lists.
+
+Start PostgreSQL:
+
+```bash
+cd backend
+docker compose -f internal/db/docker-compose.yml up -d
+```
+
+Create `backend/.env`:
+
+```bash
+GITHUB_CLIENT_ID=your_github_oauth_client_id
+GITHUB_CLIENT_SECRET=your_github_oauth_client_secret
+GITHUB_REDIRECT_URL=http://localhost:5173/callback/auth-gh
+DATABASE_URL=postgres://postgres:postgrespw@localhost:5432/cftracker?sslmode=disable
+JWT_SECRET=replace_with_a_long_random_string
+```
+
+Run the API:
+
+```bash
+make run
+```
+
+The backend listens on `http://localhost:8080`. Frontend API calls should use `VITE_BACKEND_API_URL=http://localhost:8080/api`.
+
+## Common Commands
+
+Frontend:
+
+```bash
+npm run dev      # Start Vite
+npm run build    # Build production assets
+npm run lint     # Run ESLint
+```
+
+Backend:
+
+```bash
+cd backend
+make run         # Run the API
+make build       # Build backend/tmp/main
+make test        # Run Go tests
+make watch       # Run with air if installed
+```
+
+Data refresh:
+
+```bash
+cd scripts
+npm install
+node fetch_contests.mjs
+node fetch_problems.mjs
+```
+
+## Validation Notes
+
+Use `npm run build` as the current frontend baseline. It verifies the Vite production build.
+
+The stricter `npx tsc -b` command currently reports legacy project issues outside recent page work, including `web-vitals` API changes, missing Workbox types, and an unused icon in `Menu.tsx`. Fix those separately before making `tsc -b` a required gate.
+
+When changing a focused feature, a targeted TypeScript check can still be useful:
+
+```bash
+npx tsc --noEmit --jsx react-jsx --target ES2020 --lib ES2020,DOM,DOM.Iterable --module ESNext --moduleResolution bundler --allowImportingTsExtensions --resolveJsonModule --isolatedModules --strict --noUnusedLocals --noUnusedParameters --skipLibCheck src/vite-env.d.ts path/to/file.tsx
+```
+
+## Adding a New Page
+
+1. Add the route constant in `src/util/route/path.ts`.
+2. Register the route in `src/App.tsx`.
+3. Add a navigation link in `src/components/Menu.tsx` if the page should be globally reachable.
+4. Put business logic in `useYourPage.ts`.
+5. Keep `YourPage.tsx` as a composition layer.
+6. Move larger view pieces into a feature subfolder.
+7. Add reducer, query, or data hook changes under `src/data/` only when shared state is needed.
+
+## Working With Codeforces Data
+
+Prefer the existing domain types under `src/types/CF/`. They normalize Codeforces entities and provide helper properties such as problem IDs.
+
+Avoid duplicating Codeforces URL construction. Use helpers in `src/util/util.ts`, such as `getContestUrl`, `getProblemUrl`, and `getUserSubmissionsURL`.
+
+Be mindful of Codeforces API rate limits. Existing submission fetching intentionally waits between multiple handles.
+
+## Local Storage and URL State
+
+Filter state that should survive reloads generally uses `usePersistentState`.
+
+Shareable state should use query params through `useAppSearchParams`. Current keys are:
+
+- `q`: search text.
+- `listId`: selected list while adding problems.
+
+Prefer keeping transient UI state inside the page hook.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,142 @@
-# CF Tracker
+# CFTracker
 
-Platform to view contest problems from codeforces 
+CFTracker is a Codeforces companion app for browsing contests and problems, checking solve status for one or more handles, and building practice lists.
 
-Created using 
-- React v17.0.1
-- Redux v4.0.5
-- Bootstrap v5.1.0
-- Typescript v4.2.3
+The app can run as a frontend-only tracker using public Codeforces data. An optional Go backend enables GitHub login and saved problem lists.
 
-## Prerequisites 
+## Features
 
-- node v14 or above ( for [windows](https://nodejs.org/en/download/prebuilt-installer))
-  ```bash
-  sudo apt install node #for linux 
-  ```
-- npm v9 or above
-  ```bash
-  sudo apt install npm #for linux 
-  ```
+- Contest grid grouped by contest category, with problem ratings, solve coloring, dates, and random contest selection.
+- Problem browser with search, rating range, contest ID range, tags, solve status filters, sorting, pagination, and random problem selection.
+- Multi-handle submission sync from Codeforces.
+- Stats page with verdict charts, rating breakdowns, contest category solve percentages, and a submissions heat map.
+- Optional authenticated lists for saving and organizing practice problems.
+- Dark and light themes.
 
-## Setup
+For local development workflows, see [DEVELOPMENT.md](./DEVELOPMENT.md). For contribution rules and pull request expectations, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-1) Clone repository 
-   ```bash
-    git clone https://github.com/mbashem/cftracker.git
-   ```
-2) Change to cftracker directory 
-    ```bash
-    cd cftracker
-    ```
-3) Install dependances
-   ```bash
-   npm install 
-   ```
-4) Run locally 
-   ```bash 
-   npm run start 
-   ```
+## Tech Stack
+
+- React 18
+- TypeScript 5
+- Vite 5
+- Redux Toolkit and RTK Query
+- Bootstrap and React Bootstrap
+- Chart.js and D3
+- Optional backend: Go 1.22, Gin, PostgreSQL, GitHub OAuth
+
+## Requirements
+
+- Node.js 18 or newer
+- npm 9 or newer
+- Optional backend: Go 1.22 or newer, Docker, and PostgreSQL
+
+## Frontend Setup
+
+```bash
+git clone https://github.com/mbashem/cftracker.git
+cd cftracker
+npm install
+npm run dev
+```
+
+Open the local URL printed by Vite in the terminal.
+
+The frontend-only app does not require environment variables. In local Vite development it loads problem, contest, and shared-problem data from checked-in generated files. Production builds fetch the problemset from the public Codeforces API.
+
+## Frontend Configuration
+
+Create `.env` in the repository root only when enabling backend-backed features:
+
+```bash
+VITE_BACKEND_API_URL=http://localhost:8080/api
+VITE_IS_BACKEND_AVAILABLE=true
+VITE_GITHUB_OAUTH_CLIENT_ID=your_github_oauth_client_id
+VITE_GITHUB_OAUTH_REDIRECT_URI=http://localhost:5173/callback/auth-gh
+```
+
+Leave `VITE_IS_BACKEND_AVAILABLE` unset for frontend-only mode. Backend UI is enabled only when it is set to the literal value `true`.
+
+## Backend Setup
+
+The backend is optional. It powers GitHub authentication and saved problem lists.
+
+1. Start PostgreSQL:
+
+```bash
+cd backend
+docker compose -f internal/db/docker-compose.yml up -d
+```
+
+2. Create `backend/.env`:
+
+```bash
+GITHUB_CLIENT_ID=your_github_oauth_client_id
+GITHUB_CLIENT_SECRET=your_github_oauth_client_secret
+GITHUB_REDIRECT_URL=http://localhost:5173/callback/auth-gh
+DATABASE_URL=postgres://postgres:postgrespw@localhost:5432/cftracker?sslmode=disable
+JWT_SECRET=replace_with_a_long_random_string
+```
+
+3. Run the API:
+
+```bash
+make run
+```
+
+The API runs on `http://localhost:8080` and allows requests from `http://localhost:5173`.
+
+## Scripts
+
+```bash
+npm run dev      # Start the Vite dev server
+npm run build    # Build the frontend for production
+npm run lint     # Run ESLint
+```
+
+Backend scripts are available from `backend/`:
+
+```bash
+make run         # Run the Go API
+make build       # Build backend/tmp/main
+make test        # Run Go tests
+make watch       # Run with air if available
+```
+
+## Data Refresh
+
+Contest and problem snapshots live under `src/data/saved_api`. The scheduled GitHub Action runs the scripts in `scripts/` to refresh generated contest/problem data.
+
+For a manual refresh:
+
+```bash
+cd scripts
+npm install
+node fetch_contests.mjs
+node fetch_problems.mjs
+```
+
+## Project Layout
+
+```text
+src/components/contest/    Contest page hook and modular contest table views
+src/components/problem/    Problem page hook, filters, and problem table views
+src/components/stats/      Stats page and charts
+src/components/list/       Authenticated problem-list views
+src/data/                  Redux store, reducers, RTK Query APIs, and data loaders
+src/types/                 Codeforces and app domain types
+backend/                   Optional Go API for auth and lists
+scripts/                   Data refresh scripts
+```
 
 ## Contributing
 
-1. Fork it!
-2. Create your feature branch: ```git checkout -b my-new-feature```
-3. Commit your changes: ```git commit -am 'Add some feature'```
-4. Push to the branch: ```git push origin my-new-feature```
-5. Submit a pull request :D
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull request.
+
+In short:
+
+1. Open an issue and wait for maintainer approval before starting new work.
+2. Create a focused feature branch.
+3. Run and test the affected flow locally before pushing.
+4. Run `npm run build` before opening a pull request.
+5. Update docs when behavior, setup, or development workflow changes.

--- a/manage-contests/README.md
+++ b/manage-contests/README.md
@@ -1,36 +1,34 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# manage-contests
 
-## Getting Started
+`manage-contests` is a personal admin utility for CFTracker contest/problem/shared-contest maintenance.
 
-First, run the development server:
+It is not part of the public CFTracker user-facing app. Treat it as an operator tool for local/admin tasks. It includes actions that fetch Codeforces data, sync saved data, and mutate local admin data.
+
+## Environment
+
+Create `manage-contests/.env`:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+DATABASE_URL=postgres://postgres:postgrespw@localhost:5432/cftracker_manage?sslmode=disable
+CF_API_KEY=your_codeforces_api_key
+CF_API_SECRET=your_codeforces_api_secret
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+`DATABASE_URL` is used by Prisma. `CF_API_KEY` and `CF_API_SECRET` are only needed for authenticated Codeforces API calls.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Run Locally
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+```bash
+cd manage-contests
+npm install
+npm run dev
+```
 
-## Learn More
+Open the local URL printed by Next.js in the terminal.
 
-To learn more about Next.js, take a look at the following resources:
+## Notes
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+- This tool is intended for admin usage only.
+- Do not expose it as a public deployment.
+- Saved admin snapshots live under `src/saved-db/`.
+- Prisma schema and migrations live under `src/prisma/`.

--- a/src/App.css
+++ b/src/App.css
@@ -197,3 +197,12 @@ footer {
 text.text-light {
   fill: #f8f9fa !important;
 }
+
+.date-range-input {
+  appearance: none;
+  outline: none;
+}
+
+.date-range-input::-webkit-calendar-picker-indicator {
+  display: none;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -203,6 +203,10 @@ text.text-light {
   outline: none;
 }
 
+.date-range-clear-button {
+  margin-left: -0.7rem;
+}
+
 .date-range-input::-webkit-calendar-picker-indicator {
   display: none;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -210,3 +210,70 @@ text.text-light {
 .date-range-input::-webkit-calendar-picker-indicator {
   display: none;
 }
+
+.input-range-slider {
+  height: 1.5rem;
+}
+
+.input-range-slider-light {
+  --input-range-slider-track: #dee2e6;
+  --input-range-slider-selected: #0d6efd;
+}
+
+.input-range-slider-dark {
+  --input-range-slider-track: #6c757d;
+  --input-range-slider-selected: #6ea8fe;
+}
+
+.input-range-slider-track {
+  height: 0.5rem;
+  top: 50%;
+  border-radius: 1rem;
+  pointer-events: none;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
+.input-range-slider-input {
+  inset: 0;
+  margin: 0;
+  pointer-events: none;
+}
+
+.input-range-slider-input:focus {
+  z-index: 5 !important;
+}
+
+.input-range-slider-input::-webkit-slider-runnable-track {
+  background: transparent;
+}
+
+.input-range-slider-input::-moz-range-track {
+  background: transparent;
+}
+
+.input-range-slider-input::-webkit-slider-thumb {
+  cursor: ew-resize;
+  pointer-events: auto;
+}
+
+.input-range-slider-input::-moz-range-thumb {
+  cursor: ew-resize;
+  pointer-events: auto;
+}
+
+.input-range-slider-min.input-range-slider-equal::-webkit-slider-thumb {
+  transform: translateX(-0.2rem);
+}
+
+.input-range-slider-max.input-range-slider-equal::-webkit-slider-thumb {
+  transform: translateX(0.2rem);
+}
+
+.input-range-slider-min.input-range-slider-equal::-moz-range-thumb {
+  transform: translateX(-0.2rem);
+}
+
+.input-range-slider-max.input-range-slider-equal::-moz-range-thumb {
+  transform: translateX(0.2rem);
+}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,7 +1,6 @@
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faMoon } from "@fortawesome/free-regular-svg-icons";
 import {
-  faFlask,
   faInfo,
   faScrewdriverWrench,
   faSignIn,
@@ -116,12 +115,7 @@ function Menu() {
             <li className="nav-item active">
               <Link to={Path.Stats} className="nav-link">
                 {/* <span className="p-1">{<FontAwesomeIcon icon={faBars} />}</span> */}
-                <span title="experimental">
-                  Stats
-                  <sup>
-                    <FontAwesomeIcon icon={faFlask} />
-                  </sup>
-                </span>
+                <span>Stats</span>
               </Link>
             </li>
             <li className="nav-item active">

--- a/src/components/common/CustomModal.tsx
+++ b/src/components/common/CustomModal.tsx
@@ -14,6 +14,7 @@ interface PropsType {
   children: React.ReactNode | ((props: childrenProps) => React.ReactNode);
   theme: Theme;
   button?: React.ReactNode;
+  size?: "sm" | "lg" | "xl";
 }
 
 const CustomModal = (props: PropsType) => {
@@ -27,12 +28,12 @@ const CustomModal = (props: PropsType) => {
       <button type="button" className={"btn " + props.theme.btn} onClick={handleShow}>
         {props.button === undefined ? <FontAwesomeIcon icon={faFilter} /> : props.button}
       </button>
-      <Modal className="modal" show={show} onHide={handleClose}>
+      <Modal className="modal" size={props.size} show={show} onHide={handleClose}>
         <Modal.Header className={"modal-header " + props.theme.bgText}>
           <Modal.Title>{props.title}</Modal.Title>
           <button
             type="button"
-            className="btn-close"
+            className={props.theme.btnClose}
             data-bs-dismiss="modal"
             aria-label="Close"
             onClick={() => handleClose()}

--- a/src/components/common/Filter.tsx
+++ b/src/components/common/Filter.tsx
@@ -12,7 +12,7 @@ interface PropsType {
   selected: number;
   perPage: number;
   onSearch: (s: string) => void;
-  setRandom: (num: number) => void;
+  setRandom: (num: number | undefined) => void;
   theme: Theme;
   name: string;
 }
@@ -56,7 +56,7 @@ const Filter = (props: PropsType) => {
               type="button"
               className={"btn btn-transparent text-secondary"}
               title="Cancel Random"
-              onClick={() => props.setRandom(-1)}
+              onClick={() => props.setRandom(undefined)}
             >
               <FontAwesomeIcon icon={faRedo} />
             </button>

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import Theme from "../../util/Theme";
-import { processNumber } from "../../util/util";
+import { clampNumber } from "../../util/util";
 import InputNumber from "./forms/Input/InputNumber";
 
 interface PaginationProps {
@@ -96,7 +96,7 @@ const Pagination = (props: PaginationProps) => {
                 value={props.perPage}
                 onChange={(e) => {
                   if (props.pageSize) {
-                    props.pageSize(processNumber(parseInt(e.target.value), 1, props.totalCount));
+                    props.pageSize(clampNumber(parseInt(e.target.value), 1, props.totalCount));
                   }
                 }}
               >

--- a/src/components/common/charts/CalendarHeatMap.tsx
+++ b/src/components/common/charts/CalendarHeatMap.tsx
@@ -44,8 +44,6 @@ function CalendarHeatMap({ datasets, minimumValueForMaxColor }: CalendarHeatMapP
 
   return (
     <div className="d-flex flex-column justify-content-center">
-      <span className="row justify-content-center mb-4 text-secondary fw-bold small">Submission HeatMap</span>
-
       {datasets.map((dataset) => (
         <div className="d-flex flex-column" key={dataset.year}>
           <div className="d-flex justify-content-center">

--- a/src/components/common/forms/CheckList.tsx
+++ b/src/components/common/forms/CheckList.tsx
@@ -18,6 +18,7 @@ interface PropsType<T> {
   activeClass?: string;
   inactiveClass?: string;
   btnClass?: string;
+  className?: string;
   appendButtonsEnd?: ButtonItems[];
 }
 
@@ -31,7 +32,7 @@ const CheckList = <T extends React.Key>(props: PropsType<T>) => {
   if (!activeClass) activeClass = "btn-success active";
 
   return (
-    <div className="d-flex flex-column">
+    <div className={`d-flex flex-column ${props.className ?? ""}`}>
       <div className="d-inline-flex gap-2 align-items-center">
         {props.name.length ? <div className="">{props.name}</div> : ""}
         {props.selectAll ? (

--- a/src/components/common/forms/Input/InputDateRange.tsx
+++ b/src/components/common/forms/Input/InputDateRange.tsx
@@ -55,19 +55,19 @@ function DateInput({ label, value, min, max, theme, onChange, onClear }: DateInp
       >
         <input
           ref={inputRef}
-          className={`date-range-input border-0 bg-transparent py-1 ps-2 ${theme.text}`}
+          className={`date-range-input border-0 bg-transparent ps-1 py-1 ${theme.text}`}
           type="date"
           aria-label={fieldName}
           min={min}
           max={max}
           value={value ?? ""}
-          style={{ colorScheme: theme.name, minWidth: 0, width: "8rem" }}
+          style={{ colorScheme: theme.name }}
           onChange={(event) => onChange(event.target.value)}
         />
         {value !== undefined && (
           <button
             type="button"
-            className={`btn border-0 bg-transparent p-0 ${theme.textDanger}`}
+            className={`date-range-clear-button btn border-0 bg-transparent p-0 ${theme.textDanger}`}
             aria-label={`Clear ${fieldName}`}
             title={`Clear ${fieldName}`}
             onClick={(event) => {

--- a/src/components/common/forms/Input/InputDateRange.tsx
+++ b/src/components/common/forms/Input/InputDateRange.tsx
@@ -1,0 +1,135 @@
+import { faCalendarDays, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useRef } from "react";
+import Theme from "../../../../util/Theme";
+import { formatDateInputValue } from "../../../../util/time";
+
+const earliestDate = "1970-01-01";
+
+interface InputDateRangeProps {
+  name: string;
+  minValue: string | undefined;
+  maxValue: string | undefined;
+  theme: Theme;
+  className?: string;
+  onMinChange: (value: string | undefined) => void;
+  onMaxChange: (value: string | undefined) => void;
+}
+
+interface DateInputProps {
+  label: string;
+  value: string | undefined;
+  min: string;
+  max: string;
+  theme: Theme;
+  onChange: (value: string) => void;
+  onClear: () => void;
+}
+
+function isValidDate(value: string, min: string, max: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value) || value < min || value > max) return false;
+
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+
+  return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+}
+
+function DateInput({ label, value, min, max, theme, onChange, onClear }: DateInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const fieldName = label.toLowerCase();
+
+  const openPicker = () => {
+    if (inputRef.current === null) return;
+    if (typeof inputRef.current.showPicker === "function") inputRef.current.showPicker();
+    else inputRef.current.focus();
+  };
+
+  return (
+    <div className="input-group flex-nowrap ps-1">
+      <span className={`input-group-text ${theme.bgText}`}>{label}</span>
+      <div
+        className={`form-control d-flex align-items-center p-0 ${theme.bgText}`}
+        style={{ minWidth: 0 }}
+        onClick={openPicker}
+      >
+        <input
+          ref={inputRef}
+          className={`date-range-input border-0 bg-transparent py-1 ps-2 ${theme.text}`}
+          type="date"
+          aria-label={fieldName}
+          min={min}
+          max={max}
+          value={value ?? ""}
+          style={{ colorScheme: theme.name, minWidth: 0, width: "8rem" }}
+          onChange={(event) => onChange(event.target.value)}
+        />
+        {value !== undefined && (
+          <button
+            type="button"
+            className={`btn border-0 bg-transparent p-0 ${theme.textDanger}`}
+            aria-label={`Clear ${fieldName}`}
+            title={`Clear ${fieldName}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onClear();
+            }}
+          >
+            <FontAwesomeIcon icon={faXmark} size="xs" />
+          </button>
+        )}
+        <button
+          type="button"
+          className={`btn ms-auto border-0 bg-transparent px-2 ${theme.text}`}
+          aria-label={`Open ${fieldName} picker`}
+          title={`Open ${fieldName} picker`}
+          onClick={(event) => {
+            event.stopPropagation();
+            openPicker();
+          }}
+        >
+          <FontAwesomeIcon icon={faCalendarDays} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function InputDateRange({ name, minValue, maxValue, theme, className, onMinChange, onMaxChange }: InputDateRangeProps) {
+  const today = formatDateInputValue(new Date());
+
+  const updateMin = (value: string) => {
+    if (value.length === 0) return onMinChange(undefined);
+    if (isValidDate(value, earliestDate, maxValue ?? today)) onMinChange(value);
+  };
+
+  const updateMax = (value: string) => {
+    if (value.length === 0) return onMaxChange(undefined);
+    if (isValidDate(value, minValue ?? earliestDate, today)) onMaxChange(value);
+  };
+
+  return (
+    <div className={`d-flex ${className ?? ""}`}>
+      <DateInput
+        label={`Min ${name}`}
+        value={minValue}
+        min={earliestDate}
+        max={maxValue ?? today}
+        theme={theme}
+        onChange={updateMin}
+        onClear={() => onMinChange(undefined)}
+      />
+      <DateInput
+        label={`Max ${name}`}
+        value={maxValue}
+        min={minValue ?? earliestDate}
+        max={today}
+        theme={theme}
+        onChange={updateMax}
+        onClear={() => onMaxChange(undefined)}
+      />
+    </div>
+  );
+}
+
+export default InputDateRange;

--- a/src/components/common/forms/Input/InputNumber.tsx
+++ b/src/components/common/forms/Input/InputNumber.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { processNumber } from "../../../../util/util";
+import { clampNumber } from "../../../../util/util";
 
 interface PropsType {
   header: string;
@@ -21,10 +21,10 @@ const InputNumber = (props: PropsType) => {
   const validateAndUpdate = () => {
     let num: number = parseInt(inputValue);
     if (!isNaN(num)) {
-      let processedNum = processNumber(num, props.min, props.max);
-      if (processedNum != num) {
+      let clampedNumber = clampNumber(num, props.min, props.max);
+      if (clampedNumber != num) {
         // FIXME:- It causes infinite rendering
-        // setInputValue(processedNum.toString()); // converting num to string
+        // setInputValue(clampedNumber.toString()); // converting num to string
       }
       props.onChange(num);
     }

--- a/src/components/common/forms/Input/InputRangeSlider.tsx
+++ b/src/components/common/forms/Input/InputRangeSlider.tsx
@@ -1,5 +1,5 @@
 import Theme from "../../../../util/Theme";
-import { processNumber } from "../../../../util/util";
+import { clampNumber } from "../../../../util/util";
 
 interface InputRangeSliderProps {
   name: string;
@@ -24,14 +24,12 @@ function InputRangeSlider({
   className,
   onChange,
 }: InputRangeSliderProps) {
-  const boundedMin = processNumber(minValue, min, max);
-  const boundedMax = processNumber(maxValue, min, max);
-  const selectedMin = Math.min(boundedMin, boundedMax);
-  const selectedMax = Math.max(boundedMin, boundedMax);
+  const boundedMinValue = clampNumber(minValue, min, max);
+  const boundedMaxValue = clampNumber(maxValue, min, max);
   const range = max - min;
-  const minPercentage = range === 0 ? 0 : ((selectedMin - min) / range) * 100;
-  const maxPercentage = range === 0 ? 100 : ((selectedMax - min) / range) * 100;
-  const valuesAreEqual = selectedMin === selectedMax;
+  const minPercentage = range === 0 ? 0 : ((boundedMinValue - min) / range) * 100;
+  const maxPercentage = range === 0 ? 100 : ((boundedMaxValue - min) / range) * 100;
+  const valuesAreEqual = boundedMinValue === boundedMaxValue;
 
   const trackBackground = `linear-gradient(to right,
     var(--input-range-slider-track) ${minPercentage}%,
@@ -43,10 +41,10 @@ function InputRangeSlider({
     <div className={`d-flex flex-column px-2 ${theme.bgText} ${className ?? ""}`}>
       <div className="d-flex justify-content-between align-items-center gap-2 mb-1">
         <span>
-          Min {name}: <output>{selectedMin}</output>
+          Min {name}: <output>{boundedMinValue}</output>
         </span>
         <span>
-          Max {name}: <output>{selectedMax}</output>
+          Max {name}: <output>{boundedMaxValue}</output>
         </span>
       </div>
 
@@ -63,12 +61,14 @@ function InputRangeSlider({
           min={min}
           max={max}
           step={step}
-          value={selectedMin}
+          value={boundedMinValue}
           aria-label={`Minimum ${name.toLowerCase()}`}
-          aria-valuemax={selectedMax}
-          aria-valuetext={selectedMin.toString()}
-          style={{ zIndex: selectedMin >= selectedMax - step ? 4 : 2 }}
-          onChange={(event) => onChange(Math.min(Number(event.target.value), selectedMax), selectedMax)}
+          aria-valuemax={boundedMaxValue}
+          aria-valuetext={boundedMinValue.toString()}
+          style={{ zIndex: boundedMinValue >= boundedMaxValue - step ? 4 : 2 }}
+          onChange={(event) =>
+            onChange(Math.min(Number(event.target.value), boundedMaxValue), boundedMaxValue)
+          }
         />
         <input
           className={`input-range-slider-input input-range-slider-max form-range position-absolute w-100 ${
@@ -78,12 +78,14 @@ function InputRangeSlider({
           min={min}
           max={max}
           step={step}
-          value={selectedMax}
+          value={boundedMaxValue}
           aria-label={`Maximum ${name.toLowerCase()}`}
-          aria-valuemin={selectedMin}
-          aria-valuetext={selectedMax.toString()}
+          aria-valuemin={boundedMinValue}
+          aria-valuetext={boundedMaxValue.toString()}
           style={{ zIndex: 3 }}
-          onChange={(event) => onChange(selectedMin, Math.max(Number(event.target.value), selectedMin))}
+          onChange={(event) =>
+            onChange(boundedMinValue, Math.max(Number(event.target.value), boundedMinValue))
+          }
         />
       </div>
     </div>

--- a/src/components/common/forms/Input/InputRangeSlider.tsx
+++ b/src/components/common/forms/Input/InputRangeSlider.tsx
@@ -1,0 +1,93 @@
+import Theme from "../../../../util/Theme";
+import { processNumber } from "../../../../util/util";
+
+interface InputRangeSliderProps {
+  name: string;
+  min: number;
+  max: number;
+  minValue: number;
+  maxValue: number;
+  step: number;
+  theme: Theme;
+  className?: string;
+  onChange: (minValue: number, maxValue: number) => void;
+}
+
+function InputRangeSlider({
+  name,
+  min,
+  max,
+  minValue,
+  maxValue,
+  step,
+  theme,
+  className,
+  onChange,
+}: InputRangeSliderProps) {
+  const boundedMin = processNumber(minValue, min, max);
+  const boundedMax = processNumber(maxValue, min, max);
+  const selectedMin = Math.min(boundedMin, boundedMax);
+  const selectedMax = Math.max(boundedMin, boundedMax);
+  const range = max - min;
+  const minPercentage = range === 0 ? 0 : ((selectedMin - min) / range) * 100;
+  const maxPercentage = range === 0 ? 100 : ((selectedMax - min) / range) * 100;
+  const valuesAreEqual = selectedMin === selectedMax;
+
+  const trackBackground = `linear-gradient(to right,
+    var(--input-range-slider-track) ${minPercentage}%,
+    var(--input-range-slider-selected) ${minPercentage}%,
+    var(--input-range-slider-selected) ${maxPercentage}%,
+    var(--input-range-slider-track) ${maxPercentage}%)`;
+
+  return (
+    <div className={`d-flex flex-column px-2 ${theme.bgText} ${className ?? ""}`}>
+      <div className="d-flex justify-content-between align-items-center gap-2 mb-1">
+        <span>
+          Min {name}: <output>{selectedMin}</output>
+        </span>
+        <span>
+          Max {name}: <output>{selectedMax}</output>
+        </span>
+      </div>
+
+      <div className={`input-range-slider input-range-slider-${theme.name} position-relative`}>
+        <div
+          className="input-range-slider-track position-absolute w-100"
+          style={{ background: trackBackground }}
+        />
+        <input
+          className={`input-range-slider-input input-range-slider-min form-range position-absolute w-100 ${
+            valuesAreEqual ? "input-range-slider-equal" : ""
+          }`}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={selectedMin}
+          aria-label={`Minimum ${name.toLowerCase()}`}
+          aria-valuemax={selectedMax}
+          aria-valuetext={selectedMin.toString()}
+          style={{ zIndex: selectedMin >= selectedMax - step ? 4 : 2 }}
+          onChange={(event) => onChange(Math.min(Number(event.target.value), selectedMax), selectedMax)}
+        />
+        <input
+          className={`input-range-slider-input input-range-slider-max form-range position-absolute w-100 ${
+            valuesAreEqual ? "input-range-slider-equal" : ""
+          }`}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={selectedMax}
+          aria-label={`Maximum ${name.toLowerCase()}`}
+          aria-valuemin={selectedMin}
+          aria-valuetext={selectedMax.toString()}
+          style={{ zIndex: 3 }}
+          onChange={(event) => onChange(selectedMin, Math.max(Number(event.target.value), selectedMin))}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default InputRangeSlider;

--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -46,9 +46,7 @@ function ContestPage() {
           perPage={filter.perPage}
           selected={selected}
           name="Contest"
-          setRandom={(num) => {
-            setRandomContest(num ?? -1);
-          }}
+          setRandom={setRandomContest}
           theme={theme}
         >
           <CustomModal title="filter" theme={theme}>

--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -47,7 +47,7 @@ function ContestPage() {
           selected={selected}
           name="Contest"
           setRandom={(num) => {
-            setRandomContest(num);
+            setRandomContest(num ?? -1);
           }}
           theme={theme}
         >

--- a/src/components/contest/useContestPage.ts
+++ b/src/components/contest/useContestPage.ts
@@ -55,13 +55,7 @@ function useContestPage() {
 		canSelectMultipleCategories: false,
 	};
 
-	enum ContestSave {
-		SolveStatus = "CONTEST_SOLVE_STATUS",
-		ParticipantType = "PARTICIPANT_TYPE",
-		Filter = "CONTEST_FILTER",
-	}
-
-	const [filter, setFilter] = useState<Filter>(StorageService.getObject(ContestSave.Filter, defaultFilt));
+	const [filter, setFilter] = useState<Filter>(StorageService.getObject(StorageService.Keys.Contest.Filter, defaultFilt));
 
 	const categoryFilter = useMemo(() => {
 		return {
@@ -75,8 +69,12 @@ function useContestPage() {
 	const allParticipantType = useMemo(() => Object.keys(ParticipantType), []);
 
 	const [selected, setSelected] = useState(0);
-	const [solveStatus, setSolveStatus] = useState(StorageService.getSet(ContestSave.SolveStatus, selectableVerdictStatuses));
-	const [participant, setParticipant] = useState(StorageService.getSet(ContestSave.ParticipantType, allParticipantType));
+	const [solveStatus, setSolveStatus] = useState(
+		StorageService.getSet(StorageService.Keys.Contest.SolveStatus, selectableVerdictStatuses)
+	);
+	const [participant, setParticipant] = useState(
+		StorageService.getSet(StorageService.Keys.Contest.ParticipantType, allParticipantType)
+	);
 
 	const currentPageContests = useMemo(() => {
 		if (randomContest !== -1) {
@@ -136,7 +134,7 @@ function useContestPage() {
 	}
 
 	useEffect(() => {
-		StorageService.saveObject(ContestSave.Filter, filter);
+		StorageService.saveObject(StorageService.Keys.Contest.Filter, filter);
 		if (filter.search.trim().length) updateSearchParam(SearchKeys.Search, filter.search.trim());
 		else deleteSearchParam(SearchKeys.Search);
 
@@ -159,12 +157,12 @@ function useContestPage() {
 
 	function updateSolveStatus(status: Set<Verdict>) {
 		setSolveStatus(status);
-		StorageService.saveSet(ContestSave.SolveStatus, status);
+		StorageService.saveSet(StorageService.Keys.Contest.SolveStatus, status);
 	}
 
 	function updateParticipantsType(participantType: Set<string>) {
 		setParticipant(participantType);
-		StorageService.saveSet(ContestSave.ParticipantType, participantType);
+		StorageService.saveSet(StorageService.Keys.Contest.ParticipantType, participantType);
 	}
 
 	const updateFilter = useCallback((value: UpdateFilter) => {

--- a/src/components/contest/useContestPage.ts
+++ b/src/components/contest/useContestPage.ts
@@ -42,7 +42,7 @@ function useContestPage() {
 		error: string;
 	}>({ contests: [], error: "" });
 
-	const [randomContest, setRandomContest] = useState(-1);
+	const [randomContest, setRandomContest] = useState<number | undefined>(undefined);
 
 	const defaultFilt: Filter = {
 		perPage: 100,
@@ -77,8 +77,9 @@ function useContestPage() {
 	);
 
 	const currentPageContests = useMemo(() => {
-		if (randomContest !== -1) {
-			return [contestList.contests[randomContest]];
+		if (randomContest !== undefined) {
+			const contest = contestList.contests[randomContest];
+			return contest ? [contest] : [];
 		}
 		let lo = selected * filter.perPage;
 		let high = Math.min(contestList.contests.length, lo + filter.perPage);
@@ -141,7 +142,7 @@ function useContestPage() {
 		const newContestList = contests.filter((contest) => filterContest(contest));
 
 		setContestList({ ...contestList, contests: newContestList });
-		setRandomContest(-1);
+		setRandomContest(undefined);
 	}, [state.problemList.problems, filter, solveStatus, submissions]);
 
 	useEffect(() => {

--- a/src/components/problem/ProblemFilterModal.tsx
+++ b/src/components/problem/ProblemFilterModal.tsx
@@ -3,6 +3,7 @@ import { Verdict } from "../../types/CF/Submission";
 import Theme from "../../util/Theme";
 import CustomModal from "../common/CustomModal";
 import CheckList from "../common/forms/CheckList";
+import InputDateRange from "../common/forms/Input/InputDateRange";
 import InputRange from "../common/forms/Input/InputRange";
 import type { ProblemFilter, ProblemFilterState, UpdateProblemFilter } from "./useProblemPage";
 
@@ -32,11 +33,12 @@ function ProblemFilterModal({
   setTags,
 }: ProblemFilterModalProps) {
   return (
-    <CustomModal title="Filter" theme={theme}>
+    <CustomModal title="Filter" theme={theme} size="lg">
       <CheckList
         items={selectableVerdictStatuses}
         active={solveStatus}
         name={"Solve Status"}
+        className="pb-2"
         onClickSet={setSolveStatus}
         theme={theme}
       />
@@ -49,7 +51,7 @@ function ProblemFilterModal({
         name="Rating"
         step={100}
         minTitle="Set 0 to show Unrated Problems"
-        className="p-2 pb-0"
+        className="pb-2"
         onMinChange={(num: number) => updateFilter({ minRating: num })}
         onMaxChange={(num: number) => updateFilter({ maxRating: num })}
       />
@@ -61,9 +63,18 @@ function ProblemFilterModal({
         theme={theme}
         name="ContestId"
         step={1}
-        className="p-2"
+        className="pb-2"
         onMinChange={(num: number) => updateFilter({ minContestId: num })}
         onMaxChange={(num: number) => updateFilter({ maxContestId: num })}
+      />
+      <InputDateRange
+        name="Date"
+        minValue={filter.minContestDate}
+        maxValue={filter.maxContestDate}
+        theme={theme}
+        className="pb-2"
+        onMinChange={(minContestDate) => updateFilter({ minContestDate })}
+        onMaxChange={(maxContestDate) => updateFilter({ maxContestDate })}
       />
       <CheckList
         items={tags}

--- a/src/components/problem/ProblemFilterModal.tsx
+++ b/src/components/problem/ProblemFilterModal.tsx
@@ -1,0 +1,80 @@
+import type { AppState } from "../../data/reducers/appSlice";
+import { Verdict } from "../../types/CF/Submission";
+import Theme from "../../util/Theme";
+import CustomModal from "../common/CustomModal";
+import CheckList from "../common/forms/CheckList";
+import InputRange from "../common/forms/Input/InputRange";
+import type { ProblemFilter, ProblemFilterState, UpdateProblemFilter } from "./useProblemPage";
+
+interface ProblemFilterModalProps {
+  theme: Theme;
+  appState: AppState;
+  filter: ProblemFilter;
+  filterState: ProblemFilterState;
+  selectableVerdictStatuses: Verdict[];
+  solveStatus: Set<Verdict>;
+  tags: string[];
+  updateFilter: (value: UpdateProblemFilter) => void;
+  setSolveStatus: (status: Set<Verdict>) => void;
+  setTags: (tags: Set<string>) => void;
+}
+
+function ProblemFilterModal({
+  theme,
+  appState,
+  filter,
+  filterState,
+  selectableVerdictStatuses,
+  solveStatus,
+  tags,
+  updateFilter,
+  setSolveStatus,
+  setTags,
+}: ProblemFilterModalProps) {
+  return (
+    <CustomModal title="Filter" theme={theme}>
+      <CheckList
+        items={selectableVerdictStatuses}
+        active={solveStatus}
+        name={"Solve Status"}
+        onClickSet={setSolveStatus}
+        theme={theme}
+      />
+      <InputRange
+        min={appState.minRating}
+        max={appState.maxRating}
+        minValue={filter.minRating}
+        maxValue={filter.maxRating}
+        theme={theme}
+        name="Rating"
+        step={100}
+        minTitle="Set 0 to show Unrated Problems"
+        className="p-2 pb-0"
+        onMinChange={(num: number) => updateFilter({ minRating: num })}
+        onMaxChange={(num: number) => updateFilter({ maxRating: num })}
+      />
+      <InputRange
+        min={appState.minContestId}
+        max={appState.maxContestId}
+        minValue={filter.minContestId}
+        maxValue={filter.maxContestId}
+        theme={theme}
+        name="ContestId"
+        step={1}
+        className="p-2"
+        onMinChange={(num: number) => updateFilter({ minContestId: num })}
+        onMaxChange={(num: number) => updateFilter({ maxContestId: num })}
+      />
+      <CheckList
+        items={tags}
+        active={filterState.tags}
+        name={"Tags"}
+        onClickSet={setTags}
+        selectAll={true}
+        deselectAll={true}
+      />
+    </CustomModal>
+  );
+}
+
+export default ProblemFilterModal;

--- a/src/components/problem/ProblemFilterModal.tsx
+++ b/src/components/problem/ProblemFilterModal.tsx
@@ -3,15 +3,18 @@ import { Verdict } from "../../types/CF/Submission";
 import Theme from "../../util/Theme";
 import CustomModal from "../common/CustomModal";
 import CheckList from "../common/forms/CheckList";
+import InputChecked from "../common/forms/Input/InputChecked";
 import InputDateRange from "../common/forms/Input/InputDateRange";
 import InputRange from "../common/forms/Input/InputRange";
-import type { ProblemFilter, ProblemFilterState, UpdateProblemFilter } from "./useProblemPage";
+import InputRangeSlider from "../common/forms/Input/InputRangeSlider";
+import type { ProblemFilter, ProblemFilterState, ProblemRatingRange, UpdateProblemFilter } from "./useProblemPage";
 
 interface ProblemFilterModalProps {
   theme: Theme;
   appState: AppState;
   filter: ProblemFilter;
   filterState: ProblemFilterState;
+  ratingRange: ProblemRatingRange;
   selectableVerdictStatuses: Verdict[];
   solveStatus: Set<Verdict>;
   tags: string[];
@@ -25,6 +28,7 @@ function ProblemFilterModal({
   appState,
   filter,
   filterState,
+  ratingRange,
   selectableVerdictStatuses,
   solveStatus,
   tags,
@@ -42,19 +46,28 @@ function ProblemFilterModal({
         onClickSet={setSolveStatus}
         theme={theme}
       />
-      <InputRange
-        min={appState.minRating}
-        max={appState.maxRating}
-        minValue={filter.minRating}
-        maxValue={filter.maxRating}
-        theme={theme}
-        name="Rating"
-        step={100}
-        minTitle="Set 0 to show Unrated Problems"
-        className="pb-2"
-        onMinChange={(num: number) => updateFilter({ minRating: num })}
-        onMaxChange={(num: number) => updateFilter({ maxRating: num })}
-      />
+      <div className="d-flex flex-column flex-md-row align-items-md-end gap-2 pb-2">
+        <InputRangeSlider
+          min={ratingRange.min}
+          max={ratingRange.max}
+          minValue={ratingRange.minValue}
+          maxValue={ratingRange.maxValue}
+          step={ratingRange.step}
+          theme={theme}
+          name="Rating"
+          className="flex-grow-1"
+          onChange={(minRating, maxRating) => updateFilter({ minRating, maxRating })}
+        />
+        <InputChecked
+          header="Unrated Problems"
+          name="showUnrated"
+          checked={filter.showUnrated}
+          title="Include unrated problems"
+          theme={theme}
+          className="w-auto flex-shrink-0 align-self-md-end"
+          onChange={(showUnrated) => updateFilter({ showUnrated })}
+        />
+      </div>
       <InputRange
         min={appState.minContestId}
         max={appState.maxContestId}

--- a/src/components/problem/ProblemPage.tsx
+++ b/src/components/problem/ProblemPage.tsx
@@ -1,193 +1,36 @@
-import { useEffect, useMemo, useState } from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSort, faSortDown, faSortUp } from "@fortawesome/free-solid-svg-icons";
-import { sortByRating, sortBySolveCount, sortByContestId, SortOrder, SortProblemBy } from "../../util/sortMethods";
-import ProblemList from "./ProblemList";
-import { useAppSelector } from "../../data/store";
-import Problem from "../../types/CF/Problem";
-import { Verdict } from "../../types/CF/Submission";
-import CustomModal from "../common/CustomModal";
-import CheckList from "../common/forms/CheckList";
-import Pagination from "../common/Pagination";
-import InputRange from "../common/forms/Input/InputRange";
-import { StorageService } from "../../util/StorageService";
-import useProblemPage from "./useProblemPage";
-import Loading from "../common/Loading";
-import { isDefined } from "../../util/util";
 import Filter from "../common/Filter";
+import Loading from "../common/Loading";
+import Pagination from "../common/Pagination";
+import ProblemFilterModal from "./ProblemFilterModal";
+import ProblemTable from "./problem-list/ProblemTable";
+import useProblemPage from "./useProblemPage";
 
-// TODO: Convert whole Problem Page to hooks pattern
 const ProblemPage = () => {
-  const state = useAppSelector((state) => {
-    return {
-      appState: state.appState,
-      problemList: state.problemList,
-    };
-  });
-
   const {
+    state,
     theme,
-    submissions,
-    listId,
     list,
-    searchText,
-    setSearchText,
-    addProblemToList,
-    problemsAddedTolist,
-    deleteProblemFromList,
-  } = useProblemPage();
-
-  enum SaveProblem {
-    SolveStatus = "PROBLEM_SOLVE_STATUS",
-    Tags = "PROBLEM_TAGS",
-    Filter = "PROBLEM_FILTER",
-  }
-
-  interface filt {
-    perPage: number;
-    minRating: number;
-    maxRating: number;
-    showUnrated: boolean;
-    minContestId: number;
-    maxContestId: number;
-    search: string;
-  }
-
-  const defaultFilt: filt = {
-    perPage: 100,
-    minRating: state.appState.minRating,
-    maxRating: state.appState.maxRating,
-    showUnrated: true,
-    minContestId: state.appState.minContestId,
-    maxContestId: state.appState.maxContestId,
-    search: searchText,
-  };
-
-  const [filter, setFilter] = useState<filt>(StorageService.getObject(SaveProblem.Filter, defaultFilt));
-
-  const SOLVEBUTTONS = [Verdict.SOLVED, Verdict.ATTEMPTED, Verdict.UNSOLVED];
-
-  const initFilterState = {
-    tags: StorageService.getSet(SaveProblem.Tags, Array<string>()),
-    sortBy: SortProblemBy.SolveCount,
-    order: SortOrder.Descending,
-  };
-
-  const [solveStatus, setSolveStatus] = useState(StorageService.getSet(SaveProblem.SolveStatus, SOLVEBUTTONS));
-  const [problemList, setProblemList] = useState<{
-    problems: Problem[];
-    error: string;
-  }>({
-    problems: [],
-    error: "",
-  });
-  const [tagList, setTagList] = useState({ tags: Array<string>() });
-  const [randomProblem, setRandomProblem] = useState(-1);
-  const [selected, setSelected] = useState(0);
-
-  const [filterState, setFilterState] = useState(initFilterState);
-  const [solved, setSolved] = useState(new Set<string>());
-  const [attempted, setAttempted] = useState(new Set<string>());
-
-  const filterProblem = (problem: Problem) => {
-    let containTags = false;
-
-    if (filterState.tags.size === 0) containTags = true;
-    else
-      for (let tag of problem.tags)
-        if (filterState.tags.has(tag)) {
-          containTags = true;
-          break;
-        }
-    let ratingInside = problem.rating <= filter.maxRating && problem.rating >= filter.minRating;
-
-    let contestIdInside = problem.contestId <= filter.maxContestId && problem.contestId >= filter.minContestId;
-    let status = solveStatus.has(getState(problem));
-
-    let searchIncluded = true;
-    let text = filter.search.toLowerCase().trim();
-    if (text.length)
-      searchIncluded = problem.name.toLowerCase().includes(text) || problem.id.toLowerCase().includes(text);
-
-    return status && ratingInside && containTags && searchIncluded && contestIdInside;
-  };
-
-  const getState = (problem: Problem) => {
-    if (solved.has(problem.id)) return Verdict.SOLVED;
-    if (attempted.has(problem.id)) return Verdict.ATTEMPTED;
-    return Verdict.UNSOLVED;
-  };
-
-  useEffect(() => {
-    StorageService.saveObject(SaveProblem.Filter, filter);
-
-    setSearchText(filter.search.trim());
-
-    if (isDefined(state.problemList.problems)) {
-      let newProblemsList: Problem[] = [];
-      newProblemsList = state.problemList.problems;
-      newProblemsList = newProblemsList.filter((problem: Problem) => filterProblem(problem));
-
-      if (filterState.sortBy === SortProblemBy.Rating) newProblemsList.sort(sortByRating);
-      else if (filterState.sortBy === SortProblemBy.Id) newProblemsList.sort(sortByContestId);
-      else newProblemsList.sort(sortBySolveCount);
-      if (filterState.order === SortOrder.Descending) newProblemsList.reverse();
-
-      let tags = [];
-      for (let tag of state.problemList.tags) tags.push(tag);
-      setTagList({ tags });
-      setProblemList({ ...problemList, problems: newProblemsList });
-    }
-    setRandomProblem(-1);
-    setSelected(0);
-  }, [
-    state.problemList.problems,
-    state.problemList.tags,
-    filterState,
+    problemList,
+    tagList,
+    selected,
     filter,
-    filter.search,
+    filterState,
     solveStatus,
     solved,
     attempted,
-  ]);
-
-  useEffect(() => {
-    let solv = new Set<string>();
-    let att = new Set<string>();
-
-    for (let submission of submissions) {
-      if (submission.verdict === Verdict.OK) solv.add(submission.contestId.toString() + submission.index);
-      else att.add(submission.contestId.toString() + submission.index);
-    }
-
-    setSolved(solv);
-    setAttempted(att);
-  }, [submissions]);
-
-  // TOOD: Convert to enum
-  const sortList = (sortBy: number) => {
-    if (filterState.sortBy === sortBy) setFilterState({ ...filterState, order: filterState.order ^ 1 });
-    else
-      setFilterState({
-        ...filterState,
-        ...{
-          order: sortBy === SortProblemBy.Rating ? SortOrder.Ascending : SortOrder.Descending,
-          sortBy: sortBy,
-        },
-      });
-  };
-
-  const paginate = () => {
-    let lo = selected * filter.perPage;
-    let high = Math.min(problemList.problems.length, lo + filter.perPage);
-
-    if (lo > high) return [];
-    return problemList.problems.slice(lo, high);
-  };
-
-  const nuetral = useMemo(() => <FontAwesomeIcon icon={faSort} />, []);
-  const less = useMemo(() => <FontAwesomeIcon icon={faSortUp} />, []);
-  const greater = useMemo(() => <FontAwesomeIcon icon={faSortDown} />, []);
+    currentPageProblems,
+    selectableVerdictStatuses,
+    showAddToList,
+    problemsAddedToList,
+    updateFilter,
+    setSelected,
+    setSolveStatus,
+    setTags,
+    setRandomProblem,
+    sortList,
+    addProblemToList,
+    deleteProblemFromList,
+  } = useProblemPage();
 
   return (
     <>
@@ -197,75 +40,25 @@ const ProblemPage = () => {
           searchName="problemSearch"
           searchPlaceHolder="Problem Name or Id"
           name="Problem"
-          onSearch={(e) => {
-            setFilter({ ...filter, search: e });
-          }}
+          onSearch={(search) => updateFilter({ search })}
           length={problemList.problems.length}
           perPage={filter.perPage}
           selected={selected}
-          setRandom={(num) => {
-            setRandomProblem(num);
-          }}
+          setRandom={setRandomProblem}
           theme={theme}
         >
-          <CustomModal title="Filter" theme={theme}>
-            <CheckList
-              items={SOLVEBUTTONS}
-              active={solveStatus}
-              name={"Solve Status"}
-              onClickSet={(newSet) => {
-                setSolveStatus(newSet);
-                StorageService.saveSet(SaveProblem.SolveStatus, newSet);
-              }}
-              theme={theme}
-            />
-            <InputRange
-              min={state.appState.minRating}
-              max={state.appState.maxRating}
-              minValue={filter.minRating}
-              maxValue={filter.maxRating}
-              theme={theme}
-              name="Rating"
-              step={100}
-              minTitle="Set 0 to show Unrated Problems"
-              className="p-2 pb-0"
-              onMinChange={(num: number) => {
-                setFilter({ ...filter, minRating: num });
-              }}
-              onMaxChange={(num: number) => {
-                setFilter({ ...filter, maxRating: num });
-              }}
-            />
-            <InputRange
-              min={state.appState.minContestId}
-              max={state.appState.maxContestId}
-              minValue={filter.minContestId}
-              maxValue={filter.maxContestId}
-              theme={theme}
-              name="ContestId"
-              step={1}
-              className="p-2"
-              onMinChange={(num: number) => {
-                setFilter({ ...filter, minContestId: num });
-              }}
-              onMaxChange={(num: number) => {
-                setFilter({ ...filter, maxContestId: num });
-              }}
-            />
-            <CheckList
-              items={tagList.tags}
-              active={filterState.tags}
-              name={"Tags"}
-              onClickSet={(newSet) => {
-                let myFilterState = { ...filterState };
-                myFilterState.tags = newSet;
-                setFilterState(myFilterState);
-                StorageService.saveSet(SaveProblem.Tags, newSet);
-              }}
-              selectAll={true}
-              deselectAll={true}
-            />
-          </CustomModal>
+          <ProblemFilterModal
+            theme={theme}
+            appState={state.appState}
+            filter={filter}
+            filterState={filterState}
+            selectableVerdictStatuses={selectableVerdictStatuses}
+            solveStatus={solveStatus}
+            tags={tagList.tags}
+            updateFilter={updateFilter}
+            setSolveStatus={setSolveStatus}
+            setTags={setTags}
+          />
         </Filter>
 
         <div className={"container p-0 pt-3 pb-3 " + theme.bg}>
@@ -273,65 +66,21 @@ const ProblemPage = () => {
             {state.problemList.loading ? (
               <Loading />
             ) : (
-              <table className={"table table-bordered m-0 " + theme.table}>
-                <thead className={theme.thead}>
-                  <tr>
-                    <th scope="col">#</th>
-                    <th scope="col" role="button" onClick={() => sortList(SortProblemBy.Id)}>
-                      <div className="d-flex justify-content-between">
-                        <div>ID</div>
-                        <div>
-                          {filterState.sortBy === SortProblemBy.Id
-                            ? filterState.order === SortOrder.Ascending
-                              ? less
-                              : greater
-                            : nuetral}
-                        </div>
-                      </div>
-                    </th>
-                    <th scope="col">Name</th>
-                    <th scope="col" role="button" onClick={() => sortList(SortProblemBy.Rating)}>
-                      <div className="d-flex justify-content-between">
-                        <div>Rating</div>
-                        <div>
-                          {filterState.sortBy === SortProblemBy.Rating
-                            ? filterState.order === SortOrder.Ascending
-                              ? less
-                              : greater
-                            : nuetral}
-                        </div>
-                      </div>
-                    </th>
-                    <th scope="col" role="button" onClick={() => sortList(SortProblemBy.SolveCount)}>
-                      <div className="d-flex justify-content-between">
-                        <div>Solve Count</div>
-                        <div>
-                          {filterState.sortBy === SortProblemBy.SolveCount
-                            ? filterState.order === SortOrder.Ascending
-                              ? less
-                              : greater
-                            : nuetral}
-                        </div>
-                      </div>
-                    </th>
-                    {isDefined(listId) && <th scope="col">Add To {list?.name}</th>}
-                  </tr>
-                </thead>
-                <tbody className={theme.bg}>
-                  <ProblemList
-                    problems={randomProblem === -1 ? paginate() : [problemList.problems[randomProblem]]}
-                    solved={solved}
-                    attempted={attempted}
-                    perPage={filter.perPage}
-                    pageSelected={selected}
-                    theme={theme}
-                    showAddToList={isDefined(listId)}
-                    addToList={(id) => addProblemToList(id)}
-                    problemsAddedToList={problemsAddedTolist}
-                    deleteFromList={deleteProblemFromList}
-                  />
-                </tbody>
-              </table>
+              <ProblemTable
+                problems={currentPageProblems}
+                solved={solved}
+                attempted={attempted}
+                perPage={filter.perPage}
+                pageSelected={selected}
+                theme={theme}
+                filterState={filterState}
+                showAddToList={showAddToList}
+                list={list}
+                addToList={addProblemToList}
+                problemsAddedToList={problemsAddedToList}
+                deleteFromList={deleteProblemFromList}
+                sortList={sortList}
+              />
             )}
           </div>
         </div>
@@ -343,10 +92,8 @@ const ProblemPage = () => {
           perPage={filter.perPage}
           selected={selected}
           theme={theme}
-          pageSelected={(e) => setSelected(e)}
-          pageSize={(num) => {
-            setFilter({ ...filter, perPage: num });
-          }}
+          pageSelected={(page) => setSelected(page)}
+          pageSize={(perPage) => updateFilter({ perPage })}
         />
       </footer>
     </>

--- a/src/components/problem/ProblemPage.tsx
+++ b/src/components/problem/ProblemPage.tsx
@@ -15,6 +15,7 @@ const ProblemPage = () => {
     selected,
     filter,
     filterState,
+    ratingRange,
     solveStatus,
     solved,
     attempted,
@@ -52,6 +53,7 @@ const ProblemPage = () => {
             appState={state.appState}
             filter={filter}
             filterState={filterState}
+            ratingRange={ratingRange}
             selectableVerdictStatuses={selectableVerdictStatuses}
             solveStatus={solveStatus}
             tags={tagList.tags}

--- a/src/components/problem/problem-list/ProblemList.tsx
+++ b/src/components/problem/problem-list/ProblemList.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAdd, faTrash } from "@fortawesome/free-solid-svg-icons";
-import { getProblemUrl } from "../../util/util";
-import { ATTEMPTED_PROBLEMS, SOLVED_PROBLEMS } from "../../util/constants";
-import Problem from "../../types/CF/Problem";
-import Theme from "../../util/Theme";
+import { getProblemUrl } from "../../../util/util";
+import { ATTEMPTED_PROBLEMS, SOLVED_PROBLEMS } from "../../../util/constants";
+import Problem from "../../../types/CF/Problem";
+import Theme from "../../../util/Theme";
 
 interface ProblemListProps {
   problems: Problem[];

--- a/src/components/problem/problem-list/ProblemTable.tsx
+++ b/src/components/problem/problem-list/ProblemTable.tsx
@@ -1,0 +1,91 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSort, faSortDown, faSortUp } from "@fortawesome/free-solid-svg-icons";
+import Problem from "../../../types/CF/Problem";
+import type { List } from "../../../types/list";
+import Theme from "../../../util/Theme";
+import { SortOrder, SortProblemBy } from "../../../util/sortMethods";
+import type { ProblemFilterState } from "../useProblemPage";
+import ProblemList from "./ProblemList";
+
+interface ProblemTableProps {
+  problems: Problem[];
+  perPage: number;
+  pageSelected: number;
+  theme: Theme;
+  filterState: ProblemFilterState;
+  solved: Set<string>;
+  attempted: Set<string>;
+  showAddToList: boolean;
+  list?: List;
+  problemsAddedToList: Set<string>;
+  sortList: (sortBy: SortProblemBy) => void;
+  addToList: (id: string) => void;
+  deleteFromList: (id: string) => void;
+}
+
+function ProblemTable({
+  problems,
+  perPage,
+  pageSelected,
+  theme,
+  filterState,
+  solved,
+  attempted,
+  showAddToList,
+  list,
+  problemsAddedToList,
+  sortList,
+  addToList,
+  deleteFromList,
+}: ProblemTableProps) {
+  const getSortIcon = (sortBy: SortProblemBy) => {
+    if (filterState.sortBy !== sortBy) return <FontAwesomeIcon icon={faSort} />;
+    return <FontAwesomeIcon icon={filterState.order === SortOrder.Ascending ? faSortUp : faSortDown} />;
+  };
+
+  return (
+    <table className={"table table-bordered m-0 " + theme.table}>
+      <thead className={theme.thead}>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col" role="button" onClick={() => sortList(SortProblemBy.Id)}>
+            <div className="d-flex justify-content-between">
+              <div>ID</div>
+              <div>{getSortIcon(SortProblemBy.Id)}</div>
+            </div>
+          </th>
+          <th scope="col">Name</th>
+          <th scope="col" role="button" onClick={() => sortList(SortProblemBy.Rating)}>
+            <div className="d-flex justify-content-between">
+              <div>Rating</div>
+              <div>{getSortIcon(SortProblemBy.Rating)}</div>
+            </div>
+          </th>
+          <th scope="col" role="button" onClick={() => sortList(SortProblemBy.SolveCount)}>
+            <div className="d-flex justify-content-between">
+              <div>Solve Count</div>
+              <div>{getSortIcon(SortProblemBy.SolveCount)}</div>
+            </div>
+          </th>
+          {showAddToList && <th scope="col">Add To {list?.name}</th>}
+        </tr>
+      </thead>
+      <tbody className={theme.bg}>
+        <ProblemList
+          problems={problems}
+          solved={solved}
+          attempted={attempted}
+          perPage={perPage}
+          pageSelected={pageSelected}
+          theme={theme}
+          showAddToList={showAddToList}
+          addToList={addToList}
+          problemsAddedToList={problemsAddedToList}
+          deleteFromList={deleteFromList}
+        />
+      </tbody>
+    </table>
+  );
+}
+
+export default ProblemTable;

--- a/src/components/problem/useProblemPage.ts
+++ b/src/components/problem/useProblemPage.ts
@@ -1,26 +1,173 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { SearchKeys } from "../../util/constants";
 import useSubmissionsStore from "../../data/hooks/useSubmissionsStore";
 import useTheme from "../../data/hooks/useTheme";
 import useList from "../../data/hooks/useListApi";
 import useAppSearchParams from "../../hooks/useSearchParam";
+import usePersistentState from "../../hooks/usePersistentState";
 import useProblemsStore from "../../data/hooks/useProblemsStore";
 import { useAppSelector } from "../../data/store";
 import useToast from "../../hooks/useToast";
 import { List } from "../../types/list";
+import Problem from "../../types/CF/Problem";
+import { Verdict } from "../../types/CF/Submission";
+import { StorageService } from "../../util/StorageService";
+import { isDefined } from "../../util/util";
+import { sortByContestId, sortByRating, sortBySolveCount, SortOrder, SortProblemBy } from "../../util/sortMethods";
+
+export interface ProblemFilter {
+	perPage: number;
+	minRating: number;
+	maxRating: number;
+	showUnrated: boolean;
+	minContestId: number;
+	maxContestId: number;
+	search: string;
+}
+
+export interface ProblemFilterState {
+	tags: Set<string>;
+	sortBy: SortProblemBy;
+	order: SortOrder;
+}
+
+export type UpdateProblemFilter = Partial<ProblemFilter> | ((filter: ProblemFilter) => Partial<ProblemFilter>);
+
+type ProblemSortState = Omit<ProblemFilterState, "tags">;
 
 function useProblemPage() {
-	const [searchText, setSearchTextInternal] = useState<string>("");
 	const { searchParams, updateSearchParam, deleteSearchParam } = useAppSearchParams();
 	const [listId, setListId] = useState<number | undefined>(undefined);
 	const [list, setList] = useState<List | undefined>(undefined);
 	const { submissions } = useSubmissionsStore();
 	const { theme } = useTheme();
 	const api = useList();
-	const { problemList } = useProblemsStore();
-	const [problemsAddedTolist, setProblemsAddedToList] = useState<Set<string>>(new Set());
+	const { problemList: problemStore } = useProblemsStore();
+	const [problemsAddedToList, setProblemsAddedToList] = useState<Set<string>>(new Set());
 	const appState = useAppSelector((state) => state.appState);
 	const { showErrorToast } = useToast();
+
+	const defaultFilter: ProblemFilter = {
+		perPage: 100,
+		minRating: appState.minRating,
+		maxRating: appState.maxRating,
+		showUnrated: true,
+		minContestId: appState.minContestId,
+		maxContestId: appState.maxContestId,
+		search: searchParams.get(SearchKeys.Search) ?? "",
+	};
+
+	const selectableVerdictStatuses = useMemo(() => [Verdict.SOLVED, Verdict.ATTEMPTED, Verdict.UNSOLVED], []);
+	const defaultSolveStatus = useMemo(() => new Set(selectableVerdictStatuses), [selectableVerdictStatuses]);
+	const [filter, setFilter] = usePersistentState(StorageService.Keys.Problem.Filter, defaultFilter);
+	const [tags, setTags] = usePersistentState(StorageService.Keys.Problem.Tags, new Set<string>());
+	const [filterSortState, setFilterSortState] = useState<ProblemSortState>({
+		sortBy: SortProblemBy.SolveCount,
+		order: SortOrder.Descending,
+	});
+	const [solveStatus, setSolveStatus] = usePersistentState<Set<Verdict>>(
+		StorageService.Keys.Problem.SolveStatus,
+		defaultSolveStatus
+	);
+	const [randomProblem, setRandomProblem] = useState<number | undefined>(undefined);
+	const [selected, setSelected] = useState(0);
+
+	const filterState = useMemo<ProblemFilterState>(
+		() => ({
+			tags,
+			sortBy: filterSortState.sortBy,
+			order: filterSortState.order,
+		}),
+		[filterSortState.order, filterSortState.sortBy, tags]
+	);
+
+	const state = useMemo(() => {
+		return {
+			appState,
+			problemList: problemStore,
+		};
+	}, [appState, problemStore]);
+
+	const { solved, attempted } = useMemo(() => {
+		const solved = new Set<string>();
+		const attempted = new Set<string>();
+
+		for (const submission of submissions) {
+			const problemId = submission.contestId.toString() + submission.index;
+			if (submission.verdict === Verdict.OK) solved.add(problemId);
+			else attempted.add(problemId);
+		}
+
+		return { solved, attempted };
+	}, [submissions]);
+
+	const getProblemStatus = useCallback(
+		(problem: Problem) => {
+			if (solved.has(problem.id)) return Verdict.SOLVED;
+			if (attempted.has(problem.id)) return Verdict.ATTEMPTED;
+			return Verdict.UNSOLVED;
+		},
+		[attempted, solved]
+	);
+
+	const filterProblem = useCallback(
+		(problem: Problem) => {
+			let containTags = false;
+
+			if (filterState.tags.size === 0) containTags = true;
+			else
+				for (const tag of problem.tags)
+					if (filterState.tags.has(tag)) {
+						containTags = true;
+						break;
+					}
+
+			const ratingInside = problem.rating <= filter.maxRating && problem.rating >= filter.minRating;
+			const contestIdInside = problem.contestId <= filter.maxContestId && problem.contestId >= filter.minContestId;
+			const status = solveStatus.has(getProblemStatus(problem));
+
+			let searchIncluded = true;
+			const text = filter.search.toLowerCase().trim();
+			if (text.length) searchIncluded = problem.name.toLowerCase().includes(text) || problem.id.toLowerCase().includes(text);
+
+			return status && ratingInside && containTags && searchIncluded && contestIdInside;
+		},
+		[filter, filterState.tags, getProblemStatus, solveStatus]
+	);
+
+	const filteredProblems = useMemo(() => {
+		const newProblemsList = problemStore.problems.filter((problem: Problem) => filterProblem(problem));
+
+		if (filterState.sortBy === SortProblemBy.Rating) newProblemsList.sort(sortByRating);
+		else if (filterState.sortBy === SortProblemBy.Id) newProblemsList.sort(sortByContestId);
+		else newProblemsList.sort(sortBySolveCount);
+
+		if (filterState.order === SortOrder.Descending) newProblemsList.reverse();
+
+		return newProblemsList;
+	}, [filterProblem, filterState.order, filterState.sortBy, problemStore.problems]);
+
+	const problemList = useMemo(() => {
+		return {
+			problems: filteredProblems,
+			error: problemStore.error,
+		};
+	}, [filteredProblems, problemStore.error]);
+
+	const tagList = useMemo(() => ({ tags: [...problemStore.tags] }), [problemStore.tags]);
+
+	const currentPageProblems = useMemo(() => {
+		if (randomProblem !== undefined) {
+			const problem = problemList.problems[randomProblem];
+			return problem ? [problem] : [];
+		}
+
+		const lo = selected * filter.perPage;
+		const high = Math.min(problemList.problems.length, lo + filter.perPage);
+
+		if (lo > high) return [];
+		return problemList.problems.slice(lo, high);
+	}, [filter.perPage, problemList.problems, randomProblem, selected]);
 
 	useEffect(() => {
 		if (listId === undefined) return;
@@ -37,22 +184,57 @@ function useProblemPage() {
 	useEffect(() => {
 		let listIdString = searchParams.get(SearchKeys.ListId);
 		setListId(listIdString ? parseInt(listIdString) : undefined);
-		setSearchTextInternal(searchParams.get(SearchKeys.Search) ?? "");
 	}, [searchParams]);
 
-	function setSearchText(text: string) {
-		if (text.length === 0)
-			deleteSearchParam(SearchKeys.Search);
-		else
-			updateSearchParam(SearchKeys.Search, text);
-	}
+	useEffect(() => {
+		const trimmedSearch = filter.search.trim();
+		if (trimmedSearch.length) updateSearchParam(SearchKeys.Search, trimmedSearch);
+		else deleteSearchParam(SearchKeys.Search);
+	}, [filter]);
+
+	useEffect(() => {
+		setRandomProblem(undefined);
+		setSelected(0);
+	}, [filteredProblems]);
+
+	const updateFilter = useCallback((value: UpdateProblemFilter) => {
+		setFilter((previousFilter) => ({
+			...previousFilter,
+			...(typeof value === "function" ? value(previousFilter) : value),
+		}));
+	}, []);
+
+	const updateSolveStatus = useCallback((status: Set<Verdict>) => {
+		setSolveStatus(status);
+	}, []);
+
+	const updateTags = useCallback((tags: Set<string>) => {
+		setTags(tags);
+	}, []);
+
+	const sortList = useCallback((sortBy: SortProblemBy) => {
+		setFilterSortState((previousFilterState) => {
+			if (previousFilterState.sortBy === sortBy) {
+				return {
+					...previousFilterState,
+					order: (previousFilterState.order ^ 1) as SortOrder,
+				};
+			}
+
+			return {
+				...previousFilterState,
+				order: sortBy === SortProblemBy.Rating ? SortOrder.Ascending : SortOrder.Descending,
+				sortBy,
+			};
+		});
+	}, []);
 
 	async function addProblemToList(problemId: string) {
 		if (listId === undefined) throw new Error("ListId is undefined");
 		try {
 			let res = await api.addProblemToList(listId, problemId);
 			console.log(res);
-			let newProblemsAddedToList = new Set(problemsAddedTolist);
+			let newProblemsAddedToList = new Set(problemsAddedToList);
 			newProblemsAddedToList.add(problemId);
 			setProblemsAddedToList(newProblemsAddedToList);
 			return;
@@ -66,7 +248,7 @@ function useProblemPage() {
 		try {
 			let res = await api.deleteProblemFromList(listId, problemId);
 			console.log(res);
-			let newProblemsAddedToList = new Set(problemsAddedTolist);
+			let newProblemsAddedToList = new Set(problemsAddedToList);
 			newProblemsAddedToList.delete(problemId);
 			setProblemsAddedToList(newProblemsAddedToList);
 			return;
@@ -75,7 +257,31 @@ function useProblemPage() {
 		}
 	}
 
-	return { theme, searchText, listId, list, submissions, setSearchText, addProblemToList, appState, problemList, problemsAddedTolist, deleteProblemFromList };
+	return {
+		state,
+		theme,
+		list,
+		problemList,
+		tagList,
+		selected,
+		filter,
+		filterState,
+		solveStatus,
+		solved,
+		attempted,
+		currentPageProblems,
+		selectableVerdictStatuses,
+		showAddToList: isDefined(listId),
+		problemsAddedToList,
+		updateFilter,
+		setSelected,
+		setSolveStatus: updateSolveStatus,
+		setTags: updateTags,
+		setRandomProblem,
+		sortList,
+		addProblemToList,
+		deleteProblemFromList,
+	};
 }
 
 export default useProblemPage;

--- a/src/components/problem/useProblemPage.ts
+++ b/src/components/problem/useProblemPage.ts
@@ -12,8 +12,9 @@ import { List } from "../../types/list";
 import Problem from "../../types/CF/Problem";
 import { Verdict } from "../../types/CF/Submission";
 import { StorageService } from "../../util/StorageService";
+import { RATING_CONSTANTS } from "../../util/cf";
 import { formatDateInputValue } from "../../util/time";
-import { isDefined } from "../../util/util";
+import { isDefined, processNumber } from "../../util/util";
 import { sortByContestId, sortByRating, sortBySolveCount, SortOrder, SortProblemBy } from "../../util/sortMethods";
 import useContestStore from "../../data/hooks/useContestStore";
 
@@ -35,9 +36,33 @@ export interface ProblemFilterState {
 	order: SortOrder;
 }
 
+export interface ProblemRatingRange {
+	min: number;
+	max: number;
+	step: number;
+	minValue: number;
+	maxValue: number;
+}
+
 export type UpdateProblemFilter = Partial<ProblemFilter> | ((filter: ProblemFilter) => Partial<ProblemFilter>);
 
 type ProblemSortState = Omit<ProblemFilterState, "tags">;
+
+function getRatingRange(minRating: number, maxRating: number): ProblemRatingRange {
+	const { min, max, interval: step } = RATING_CONSTANTS;
+	const boundedMin = processNumber(minRating, min, max);
+	const boundedMax = processNumber(maxRating, min, max);
+	const steppedMin = min + Math.floor((boundedMin - min) / step) * step;
+	const steppedMax = min + Math.ceil((boundedMax - min) / step) * step;
+
+	return {
+		min,
+		max,
+		step,
+		minValue: Math.min(steppedMin, steppedMax),
+		maxValue: Math.max(steppedMin, steppedMax),
+	};
+}
 
 function useProblemPage() {
 	const { searchParams, updateSearchParam, deleteSearchParam } = useAppSearchParams();
@@ -54,8 +79,8 @@ function useProblemPage() {
 
 	const defaultFilter: ProblemFilter = {
 		perPage: 100,
-		minRating: appState.minRating,
-		maxRating: appState.maxRating,
+		minRating: RATING_CONSTANTS.min,
+		maxRating: RATING_CONSTANTS.max,
 		showUnrated: true,
 		minContestId: appState.minContestId,
 		maxContestId: appState.maxContestId,
@@ -86,6 +111,11 @@ function useProblemPage() {
 			order: filterSortState.order,
 		}),
 		[filterSortState.order, filterSortState.sortBy, tags]
+	);
+
+	const ratingRange = useMemo(
+		() => getRatingRange(filter.minRating, filter.maxRating),
+		[filter.maxRating, filter.minRating]
 	);
 
 	const state = useMemo(() => {
@@ -140,7 +170,9 @@ function useProblemPage() {
 						break;
 					}
 
-			const ratingInside = problem.rating <= filter.maxRating && problem.rating >= filter.minRating;
+			const ratingInside = problem.rating > 0
+				? problem.rating <= ratingRange.maxValue && problem.rating >= ratingRange.minValue
+				: filter.showUnrated;
 			const contestIdInside = problem.contestId <= filter.maxContestId && problem.contestId >= filter.minContestId;
 			const contestDate = contestDates.get(problem.contestId);
 			const contestDateInside = contestDate === undefined || (
@@ -155,7 +187,7 @@ function useProblemPage() {
 
 			return status && ratingInside && containTags && searchIncluded && contestIdInside && contestDateInside;
 		},
-		[contestDates, filter, filterState.tags, getProblemStatus, solveStatus]
+		[contestDates, filter, filterState.tags, getProblemStatus, ratingRange, solveStatus]
 	);
 
 	const filteredProblems = useMemo(() => {
@@ -289,6 +321,7 @@ function useProblemPage() {
 		selected,
 		filter,
 		filterState,
+		ratingRange,
 		solveStatus,
 		solved,
 		attempted,

--- a/src/components/problem/useProblemPage.ts
+++ b/src/components/problem/useProblemPage.ts
@@ -14,7 +14,7 @@ import { Verdict } from "../../types/CF/Submission";
 import { StorageService } from "../../util/StorageService";
 import { RATING_CONSTANTS } from "../../util/cf";
 import { formatDateInputValue } from "../../util/time";
-import { isDefined, processNumber } from "../../util/util";
+import { clampNumber, isDefined } from "../../util/util";
 import { sortByContestId, sortByRating, sortBySolveCount, SortOrder, SortProblemBy } from "../../util/sortMethods";
 import useContestStore from "../../data/hooks/useContestStore";
 
@@ -50,8 +50,8 @@ type ProblemSortState = Omit<ProblemFilterState, "tags">;
 
 function getRatingRange(minRating: number, maxRating: number): ProblemRatingRange {
 	const { min, max, interval: step } = RATING_CONSTANTS;
-	const boundedMin = processNumber(minRating, min, max);
-	const boundedMax = processNumber(maxRating, min, max);
+	const boundedMin = clampNumber(minRating, min, max);
+	const boundedMax = clampNumber(maxRating, min, max);
 	const steppedMin = min + Math.floor((boundedMin - min) / step) * step;
 	const steppedMax = min + Math.ceil((boundedMax - min) / step) * step;
 

--- a/src/components/problem/useProblemPage.ts
+++ b/src/components/problem/useProblemPage.ts
@@ -12,6 +12,7 @@ import { List } from "../../types/list";
 import Problem from "../../types/CF/Problem";
 import { Verdict } from "../../types/CF/Submission";
 import { StorageService } from "../../util/StorageService";
+import { formatDateInputValue } from "../../util/time";
 import { isDefined } from "../../util/util";
 import { sortByContestId, sortByRating, sortBySolveCount, SortOrder, SortProblemBy } from "../../util/sortMethods";
 
@@ -22,6 +23,8 @@ export interface ProblemFilter {
 	showUnrated: boolean;
 	minContestId: number;
 	maxContestId: number;
+	minContestDate: string | undefined;
+	maxContestDate: string | undefined;
 	search: string;
 }
 
@@ -45,6 +48,7 @@ function useProblemPage() {
 	const { problemList: problemStore } = useProblemsStore();
 	const [problemsAddedToList, setProblemsAddedToList] = useState<Set<string>>(new Set());
 	const appState = useAppSelector((state) => state.appState);
+	const contests = useAppSelector((state) => state.contestList.contests);
 	const { showErrorToast } = useToast();
 
 	const defaultFilter: ProblemFilter = {
@@ -54,6 +58,8 @@ function useProblemPage() {
 		showUnrated: true,
 		minContestId: appState.minContestId,
 		maxContestId: appState.maxContestId,
+		minContestDate: undefined,
+		maxContestDate: undefined,
 		search: searchParams.get(SearchKeys.Search) ?? "",
 	};
 
@@ -87,6 +93,17 @@ function useProblemPage() {
 			problemList: problemStore,
 		};
 	}, [appState, problemStore]);
+
+	const contestDates = useMemo(() => {
+		const dates = new Map<number, string>();
+
+		for (const contest of contests) {
+			if (contest.startTimeSeconds === undefined) continue;
+			dates.set(contest.id, formatDateInputValue(new Date(contest.startTimeSeconds * 1000)));
+		}
+
+		return dates;
+	}, [contests]);
 
 	const { solved, attempted } = useMemo(() => {
 		const solved = new Set<string>();
@@ -124,15 +141,20 @@ function useProblemPage() {
 
 			const ratingInside = problem.rating <= filter.maxRating && problem.rating >= filter.minRating;
 			const contestIdInside = problem.contestId <= filter.maxContestId && problem.contestId >= filter.minContestId;
+			const contestDate = contestDates.get(problem.contestId);
+			const contestDateInside = contestDate === undefined || (
+				(filter.minContestDate === undefined || contestDate >= filter.minContestDate) &&
+				(filter.maxContestDate === undefined || contestDate <= filter.maxContestDate)
+			);
 			const status = solveStatus.has(getProblemStatus(problem));
 
 			let searchIncluded = true;
 			const text = filter.search.toLowerCase().trim();
 			if (text.length) searchIncluded = problem.name.toLowerCase().includes(text) || problem.id.toLowerCase().includes(text);
 
-			return status && ratingInside && containTags && searchIncluded && contestIdInside;
+			return status && ratingInside && containTags && searchIncluded && contestIdInside && contestDateInside;
 		},
-		[filter, filterState.tags, getProblemStatus, solveStatus]
+		[contestDates, filter, filterState.tags, getProblemStatus, solveStatus]
 	);
 
 	const filteredProblems = useMemo(() => {

--- a/src/components/problem/useProblemPage.ts
+++ b/src/components/problem/useProblemPage.ts
@@ -15,6 +15,7 @@ import { StorageService } from "../../util/StorageService";
 import { formatDateInputValue } from "../../util/time";
 import { isDefined } from "../../util/util";
 import { sortByContestId, sortByRating, sortBySolveCount, SortOrder, SortProblemBy } from "../../util/sortMethods";
+import useContestStore from "../../data/hooks/useContestStore";
 
 export interface ProblemFilter {
 	perPage: number;
@@ -48,7 +49,7 @@ function useProblemPage() {
 	const { problemList: problemStore } = useProblemsStore();
 	const [problemsAddedToList, setProblemsAddedToList] = useState<Set<string>>(new Set());
 	const appState = useAppSelector((state) => state.appState);
-	const contests = useAppSelector((state) => state.contestList.contests);
+	const { contests } = useContestStore();
 	const { showErrorToast } = useToast();
 
 	const defaultFilter: ProblemFilter = {

--- a/src/components/stats/StatPage.tsx
+++ b/src/components/stats/StatPage.tsx
@@ -11,7 +11,11 @@ import useStatPage from "./useStatPage";
  * percentage of problem solved by rating
  */
 const StatPage = () => {
-  const { problemIDsBySimpleVerdict, submissionsByVerdict } = useStatPage();
+  const { problemIDsBySimpleVerdict, submissionsByVerdict, hasSubmissionData } = useStatPage();
+
+  if (!hasSubmissionData) {
+    return <div className="container py-5 text-center text-secondary">No data available</div>;
+  }
 
   return (
     <div className="container pb-5">

--- a/src/components/stats/charts/ContestCategoriesByACPercentage.tsx
+++ b/src/components/stats/charts/ContestCategoriesByACPercentage.tsx
@@ -7,12 +7,11 @@ import DefaultValueMap from "../../../util/DefaultValueMap";
 import ContestCategoryByACPercentage from "./ContestCategoryByACPercentage";
 
 interface ContestCategoryByACPercentageProps {}
+const categories = Object.values(ContestCat) as ContestCat[];
 
 function ContestCategoriesByACPercentage({}: ContestCategoryByACPercentageProps) {
   const { rawSubmissions: submissions } = useSubmissionsStore();
   const { contests } = useContestStore();
-
-  const categories = Object.values(ContestCat) as ContestCat[];
 
   const contestByCategory = useMemo(() => {
     let contestByCategory = new DefaultValueMap<number, ContestCat>();
@@ -37,17 +36,25 @@ function ContestCategoriesByACPercentage({}: ContestCategoryByACPercentageProps)
     return simpleVerdictByContestCategory;
   }, [contestByCategory, submissions]);
 
+  const categoriesWithData = useMemo(
+    () => categories.filter((category) => {
+      const verdictCounts = simpleVerdictByContestCategory.get(category);
+      return verdictCounts !== undefined && [...verdictCounts.values()].some((count) => count > 0);
+    }),
+    [simpleVerdictByContestCategory]
+  );
+
   return (
     <div className="container">
       <div className="row text-secondary text-center w-100">
         <span className="small fw-bold">Contest Categories By AC Percentage </span>
       </div>
       <div className="row">
-        {categories.map((category) => (
+        {categoriesWithData.map((category) => (
           <div className="col-6 col-md-3" key={category}>
             <ContestCategoryByACPercentage
               category={category}
-              simpleVerdictCounts={simpleVerdictByContestCategory.get(category) ?? new DefaultValueMap()}
+              simpleVerdictCounts={simpleVerdictByContestCategory.get(category)!}
             />
           </div>
         ))}

--- a/src/components/stats/charts/SubmissionsHeatMap.tsx
+++ b/src/components/stats/charts/SubmissionsHeatMap.tsx
@@ -1,11 +1,19 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import useSubmissionsStore from "../../../data/hooks/useSubmissionsStore";
+import useTheme from "../../../data/hooks/useTheme";
+import usePersistentState from "../../../hooks/usePersistentState";
+import { StorageService } from "../../../util/StorageService";
 import CalendarHeatMap, { CalendarHeatMapDataSet } from "../../common/charts/CalendarHeatMap";
 
-interface SubmissionsHeatMap {}
+const allYears = "all";
 
-function SubmissionsHeatMap({}: SubmissionsHeatMap) {
+function SubmissionsHeatMap() {
   const { rawSubmissions: submissions } = useSubmissionsStore();
+  const { theme } = useTheme();
+  const [selectedYear, setSelectedYear] = usePersistentState<number | typeof allYears | undefined>(
+    StorageService.Keys.Stats.SubmissionHeatMapYear,
+    undefined
+  );
 
   const datasets = useMemo(() => {
     let datasets: CalendarHeatMapDataSet[] = [];
@@ -33,6 +41,19 @@ function SubmissionsHeatMap({}: SubmissionsHeatMap) {
     return datasets;
   }, [submissions]);
 
+  const years = useMemo(() => datasets.map((dataset) => dataset.year).reverse(), [datasets]);
+  const activeYear = selectedYear === allYears || (selectedYear !== undefined && years.includes(selectedYear))
+    ? selectedYear
+    : years[0] ?? allYears;
+  const visibleDatasets = useMemo(
+    () => activeYear === allYears ? datasets : datasets.filter((dataset) => dataset.year === activeYear),
+    [activeYear, datasets]
+  );
+
+  useEffect(() => {
+    if (years.length > 0 && selectedYear !== activeYear) setSelectedYear(activeYear);
+  }, [activeYear, selectedYear, setSelectedYear, years.length]);
+
   function isSameDay(date1: Date, date2: Date): boolean {
     return (
       date1.getDate() === date2.getDate() &&
@@ -41,7 +62,29 @@ function SubmissionsHeatMap({}: SubmissionsHeatMap) {
     );
   }
 
-  return <CalendarHeatMap datasets={datasets} minimumValueForMaxColor={5} />;
+  return (
+    <div className="d-flex flex-column w-100">
+      <div className="d-flex justify-content-center align-items-center gap-3 mb-4">
+        <span className="text-secondary fw-bold small">Submission HeatMap</span>
+        <select
+          className={`form-select form-select-sm w-auto ${theme.bgText}`}
+          aria-label="Select heatmap year"
+          value={activeYear}
+          onChange={(event) => {
+            setSelectedYear(event.target.value === allYears ? allYears : Number(event.target.value));
+          }}
+        >
+          <option value={allYears}>All</option>
+          {years.map((year) => (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          ))}
+        </select>
+      </div>
+      <CalendarHeatMap datasets={visibleDatasets} minimumValueForMaxColor={5} />
+    </div>
+  );
 }
 
 export default SubmissionsHeatMap;

--- a/src/components/stats/useStatPage.ts
+++ b/src/components/stats/useStatPage.ts
@@ -45,7 +45,12 @@ function useStatPage() {
 	}
 
 
-	return { submissionsByVerdict, problemIDsBySimpleVerdict, theme };
+	return {
+		submissionsByVerdict,
+		problemIDsBySimpleVerdict,
+		hasSubmissionData: rawSubmissions.length > 0,
+		theme,
+	};
 }
 
 export default useStatPage;

--- a/src/data/actions/fetchActions.ts
+++ b/src/data/actions/fetchActions.ts
@@ -8,57 +8,77 @@ import Contest from "../../types/CF/Contest";
 import { addProblems, errorFetchingProblems, loadingProblems } from "../reducers/problemListSlice";
 import { addContestList, errorFetchingContestList, loadingContestList } from "../reducers/contestListSlice";
 import { addSharedProblems, errorFetchingSharedProblems } from "../reducers/sharedProblemsSlice";
+import { IS_DEBUG_MODE } from "../../util/env";
 
 // const allContestURL = "https://codeforces.com/api/contest.list?lang=en";
 const problemSetURL = "https://codeforces.com/api/problemset.problems?lang=en";
 
+interface ProblemSetResult {
+  status: string;
+  result: {
+    problems: Problem[];
+    problemStatistics: ProblemStatistics[];
+  };
+}
+
+function addProblemListFromResult(dispatch: AppDispatch, result: ProblemSetResult) {
+  if (result.status !== "OK")
+    return dispatch(
+      errorFetchingProblems({ error: "Failed to fetch Problems list from CF API" })
+    );
+
+  let problems: Problem[] = result.result.problems as Problem[];
+  let problemStatistics: ProblemStatistics[] =
+    result.result.problemStatistics as ProblemStatistics[];
+
+  problems = problems.filter((problem) =>
+    problem.contestId ? true : false
+  );
+
+  problemStatistics = problemStatistics.filter((problem) =>
+    problem.contestId ? true : false
+  );
+
+  const finalProblemArray: Problem[] = [];
+  for (let index = 0; index < problems.length; index++) {
+    problems[index].rating = problems[index].rating ?? 0;
+    problems[index].solvedCount = problems[index].solvedCount ?? 0;
+    if (problems[index].contestId === undefined) continue;
+    finalProblemArray.push(
+      new Problem(
+        problems[index].contestId!,
+        problems[index].index,
+        problems[index].name,
+        problems[index].type,
+        problems[index].rating,
+        problems[index].tags,
+        problemStatistics[index]?.solvedCount ?? 0
+      )
+    );
+  }
+
+  return dispatch(addProblems({ problems: finalProblemArray }));
+}
+
 export const fetchProblemList = (dispatch: AppDispatch) => {
   dispatch(loadingProblems());
-  // import("../saved_api/problems_data")
-  //   .then(
-  //     (data) => {
-  //       let result = data.problem_data;
+
+  if (IS_DEBUG_MODE) {
+    console.log("CFTracker is running in debug mode. Using local saved problems data.");
+    import("../saved_api/problems_data")
+      .then((data) => addProblemListFromResult(dispatch, data.problem_data as ProblemSetResult))
+      .catch((error) => {
+        console.log(error);
+        return dispatch(errorFetchingProblems({ error: "Failed to load saved Problems list." }));
+      });
+    return;
+  }
+
   fetch(problemSetURL)
-    .then((res) => res.json())
+    .then((response) => response.json())
     .then(
       (result) => {
-        if (result.status !== "OK")
-          return dispatch(
-            errorFetchingProblems({ error: "Failed to fetch Problems list from CF API" })
-          );
-        //   console.log(result);
-        let problems: Problem[] = result.result.problems as Problem[];
-        let problemStatistics: ProblemStatistics[] =
-          result.result.problemStatistics as ProblemStatistics[];
-
-        problems = problems.filter((problem) =>
-          problem.contestId ? true : false
-        );
-
-        problemStatistics = problemStatistics.filter((problem) =>
-          problem.contestId ? true : false
-        );
-
-        const finalProblemArray: Problem[] = [];
-        for (let i = 0; i < problems.length; i++) {
-          problems[i].rating = problems[i].rating ?? 0;
-          problems[i].solvedCount = problems[i].solvedCount ?? 0;
-          if (problems[i].contestId === undefined) continue;
-          finalProblemArray.push(
-            new Problem(
-              problems[i].contestId!,
-              problems[i].index,
-              problems[i].name,
-              problems[i].type,
-              problems[i].rating,
-              problems[i].tags,
-              problemStatistics[i].solvedCount
-            )
-          );
-        }
-
-        return dispatch(addProblems({ problems: finalProblemArray }));
-        //	console.log(result.result.length)
+        return addProblemListFromResult(dispatch, result as ProblemSetResult);
       },
       // Note: it's important to handle errors here
       // instead of a catch() block so that we don't swallow

--- a/src/data/actions/userActions.ts
+++ b/src/data/actions/userActions.ts
@@ -8,6 +8,12 @@ import { AppDispatch } from "../store";
 import { addHandle, removeAllHandle } from "../reducers/userSlice";
 import { addUserSubmissions, clearAllUsersSubmissions, errorFetchingUserSubmissions, loadingUserSubmissions } from "../reducers/userSubmissionsSlice";
 import { delay } from "../../util/time";
+import { fetchCodeforcesApi } from "../../util/codeforcesApi";
+
+interface UserSubmissionsResponse {
+  status: string;
+  result: Submission[];
+}
 
 export const fetchUsers = (dispatch: AppDispatch, handle: string) => {
   let currentId = Date.now();
@@ -46,8 +52,7 @@ export const fetchUserSubmissions = async (
       await delay(1000);
     cnt++;
 
-    fetch(getUserSubmissionsURL(handle))
-      .then((res) => res.json())
+    fetchCodeforcesApi<UserSubmissionsResponse>(getUserSubmissionsURL(handle))
       .then(
         (result) => {
           if (result.status !== "OK")

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -29,7 +29,7 @@ const saveToLocalStorage = (state: RootState) => {
       userList: state.userList,
       appState: state.appState,
     };
-    StorageService.saveObject("statev2", newState);
+    StorageService.saveObject(StorageService.Keys.StateV2, newState);
   } catch (e) {
     console.log(e);
   }
@@ -37,7 +37,7 @@ const saveToLocalStorage = (state: RootState) => {
 
 const loadFromLocalStorage = (): any => {
   try {
-    const persedData = StorageService.getObject("statev2", {});
+    const persedData = StorageService.getObject(StorageService.Keys.StateV2, {});
 
     console.log(persedData);
     return persedData;

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,53 @@
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { StorageService } from "../util/StorageService";
+
+enum PersistentValueType {
+  Object,
+  Set,
+  Map,
+}
+
+function getPersistentValueType(value: unknown): PersistentValueType {
+  if (value instanceof Set) return PersistentValueType.Set;
+  if (value instanceof Map) return PersistentValueType.Map;
+  return PersistentValueType.Object;
+}
+
+function getPersistentValue<T>(key: string, defaultValue: T, type: PersistentValueType): T {
+  if (type === PersistentValueType.Set) {
+    return StorageService.getSet(key, defaultValue as Iterable<unknown>) as T;
+  }
+
+  if (type === PersistentValueType.Map) {
+    return StorageService.getMap(key, defaultValue as Iterable<[unknown, unknown]>) as T;
+  }
+
+  return StorageService.getObject(key, defaultValue);
+}
+
+function savePersistentValue<T>(key: string, value: T, type: PersistentValueType) {
+  if (type === PersistentValueType.Set) {
+    StorageService.saveSet(key, value as Set<unknown>);
+    return;
+  }
+
+  if (type === PersistentValueType.Map) {
+    StorageService.saveMap(key, value as Map<unknown, unknown>);
+    return;
+  }
+
+  StorageService.saveObject(key, value);
+}
+
+function usePersistentState<T>(key: string, defaultValue: T): [T, Dispatch<SetStateAction<T>>] {
+  const [valueType] = useState(() => getPersistentValueType(defaultValue));
+  const [value, setValue] = useState<T>(() => getPersistentValue(key, defaultValue, valueType));
+
+  useEffect(() => {
+    savePersistentValue(key, value, valueType);
+  }, [key, value, valueType]);
+
+  return [value, setValue];
+}
+
+export default usePersistentState;

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,37 +1,25 @@
 import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { StorageService } from "../util/StorageService";
 
-enum PersistentValueType {
-  Object,
-  Set,
-  Map,
-}
-
-function getPersistentValueType(value: unknown): PersistentValueType {
-  if (value instanceof Set) return PersistentValueType.Set;
-  if (value instanceof Map) return PersistentValueType.Map;
-  return PersistentValueType.Object;
-}
-
-function getPersistentValue<T>(key: string, defaultValue: T, type: PersistentValueType): T {
-  if (type === PersistentValueType.Set) {
+function getPersistentValue<T>(key: string, defaultValue: T): T {
+  if (defaultValue instanceof Set) {
     return StorageService.getSet(key, defaultValue as Iterable<unknown>) as T;
   }
 
-  if (type === PersistentValueType.Map) {
+  if (defaultValue instanceof Map) {
     return StorageService.getMap(key, defaultValue as Iterable<[unknown, unknown]>) as T;
   }
 
   return StorageService.getObject(key, defaultValue);
 }
 
-function savePersistentValue<T>(key: string, value: T, type: PersistentValueType) {
-  if (type === PersistentValueType.Set) {
+function savePersistentValue<T>(key: string, value: T) {
+  if (value instanceof Set) {
     StorageService.saveSet(key, value as Set<unknown>);
     return;
   }
 
-  if (type === PersistentValueType.Map) {
+  if (value instanceof Map) {
     StorageService.saveMap(key, value as Map<unknown, unknown>);
     return;
   }
@@ -40,12 +28,11 @@ function savePersistentValue<T>(key: string, value: T, type: PersistentValueType
 }
 
 function usePersistentState<T>(key: string, defaultValue: T): [T, Dispatch<SetStateAction<T>>] {
-  const [valueType] = useState(() => getPersistentValueType(defaultValue));
-  const [value, setValue] = useState<T>(() => getPersistentValue(key, defaultValue, valueType));
+  const [value, setValue] = useState<T>(() => getPersistentValue(key, defaultValue));
 
   useEffect(() => {
-    savePersistentValue(key, value, valueType);
-  }, [key, value, valueType]);
+    savePersistentValue(key, value);
+  }, [key, value]);
 
   return [value, setValue];
 }

--- a/src/util/StorageService.ts
+++ b/src/util/StorageService.ts
@@ -14,6 +14,14 @@ export namespace StorageService {
       export const SolveStatus = "CONTEST_SOLVE_STATUS";
       export const ParticipantType = "PARTICIPANT_TYPE";
     }
+
+    export namespace Codeforces {
+      export const DebugApiCache = "DEBUG_CODEFORCES_API_CACHE";
+    }
+
+    export namespace Stats {
+      export const SubmissionHeatMapYear = "STATS_SUBMISSION_HEATMAP_YEAR";
+    }
   }
 
   function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/src/util/StorageService.ts
+++ b/src/util/StorageService.ts
@@ -1,65 +1,118 @@
 export namespace StorageService {
-  enum Key {
-    jwtToken = "jwtToken"
+  export namespace Keys {
+    export const JwtToken = "jwtToken";
+    export const StateV2 = "statev2";
+
+    export namespace Problem {
+      export const Filter = "PROBLEM_FILTER";
+      export const Tags = "PROBLEM_TAGS";
+      export const SolveStatus = "PROBLEM_SOLVE_STATUS";
+    }
+
+    export namespace Contest {
+      export const Filter = "CONTEST_FILTER";
+      export const SolveStatus = "CONTEST_SOLVE_STATUS";
+      export const ParticipantType = "PARTICIPANT_TYPE";
+    }
   }
+
+  function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value) && !(value instanceof Set) && !(value instanceof Map);
+  }
+
   export function getJWTToken() {
-    return localStorage.getItem(Key.jwtToken);
+    return localStorage.getItem(Keys.JwtToken);
   }
 
   export function setJWTToken(jwtToken: string) {
-    localStorage.setItem(Key.jwtToken, jwtToken);
+    localStorage.setItem(Keys.JwtToken, jwtToken);
   }
 
   export function removeJWTToken() {
-    localStorage.removeItem(Key.jwtToken);
+    localStorage.removeItem(Keys.JwtToken);
   }
 
-  export const saveSet = <T extends string | number | boolean>(name: string, st: Set<T>): boolean => {
+  export const saveSet = <T>(storageKey: string, valueSet: Set<T>): boolean => {
     try {
-      localStorage.setItem(name, JSON.stringify([...st]));
+      localStorage.setItem(storageKey, JSON.stringify([...valueSet]));
       return true;
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
+      console.log(error);
       return false;
     }
   };
 
-  export const getSet = <T extends string | number | boolean>(name: string, def: T[]): Set<T> => {
+  export const getSet = <T>(storageKey: string, defaultValue: Iterable<T>): Set<T> => {
     try {
-      let res = JSON.parse(localStorage.getItem(name)!);
+      const storedValue = localStorage.getItem(storageKey);
+      if (storedValue === null) return new Set(defaultValue);
 
-      if (res) {
-        let st = new Set<T>(res);
-        return st;
+      let parsedValue = JSON.parse(storedValue);
+
+      if (parsedValue) {
+        let valueSet = new Set<T>(parsedValue);
+        return valueSet;
       }
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
+      console.log(error);
     }
-    return new Set(def);
+    return new Set(defaultValue);
   };
 
-  export const saveObject = (name: string, obj: any): boolean => {
+  export const saveMap = <MapKey, MapValue>(storageKey: string, valueMap: Map<MapKey, MapValue>): boolean => {
     try {
-      // console.log();
-      localStorage.setItem(name, JSON.stringify(obj));
+      localStorage.setItem(storageKey, JSON.stringify([...valueMap]));
       return true;
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
+      console.log(error);
       return false;
     }
   };
 
-  export const getObject = (name: string, def: any): any => {
+  export const getMap = <MapKey, MapValue>(
+    storageKey: string,
+    defaultValue: Iterable<[MapKey, MapValue]>
+  ): Map<MapKey, MapValue> => {
     try {
-      let res = JSON.parse(localStorage.getItem(name)!);
+      const storedValue = localStorage.getItem(storageKey);
+      if (storedValue === null) return new Map(defaultValue);
 
-      if (res) {
-        return { ...def, ...res };
+      let parsedValue = JSON.parse(storedValue);
+
+      if (parsedValue) {
+        return new Map<MapKey, MapValue>(parsedValue);
       }
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
+      console.log(error);
     }
-    return def;
+    return new Map(defaultValue);
+  };
+
+  export const saveObject = <T>(storageKey: string, value: T): boolean => {
+    try {
+      const serializedObject = JSON.stringify(value);
+      if (serializedObject === undefined) localStorage.removeItem(storageKey);
+      else localStorage.setItem(storageKey, serializedObject);
+      return true;
+    } catch (error) {
+      console.log(error);
+      return false;
+    }
+  };
+
+  export const getObject = <T>(storageKey: string, defaultValue: T): T => {
+    try {
+      const storedValue = localStorage.getItem(storageKey);
+      if (storedValue === null) return defaultValue;
+
+      let parsedValue = JSON.parse(storedValue);
+
+      if (isPlainObject(defaultValue) && isPlainObject(parsedValue)) return { ...defaultValue, ...parsedValue } as T;
+      return parsedValue as T;
+    } catch (error) {
+      console.log(error);
+    }
+    return defaultValue;
   };
 
 }

--- a/src/util/Theme.ts
+++ b/src/util/Theme.ts
@@ -52,6 +52,7 @@ export default class Theme {
   btnPrimary: string;
 
   btn: string;
+  btnClose: string;
   btnDanger: string;
   btnSuccess: string;
 
@@ -70,6 +71,7 @@ export default class Theme {
         this.bgDanger = "bg-danger";
 
         this.btn = "btn btn-dark";
+        this.btnClose = "btn-close btn-close-white";
         break;
       case ThemesType.LIGHT:
       default:
@@ -85,6 +87,7 @@ export default class Theme {
         this.bgDanger = "bg-danger-light";
 
         this.btn = "btn btn-light";
+        this.btnClose = "btn-close";
         break;
     }
 

--- a/src/util/codeforcesApi.ts
+++ b/src/util/codeforcesApi.ts
@@ -1,0 +1,64 @@
+import { IS_DEBUG_MODE } from "./env";
+import { StorageService } from "./StorageService";
+
+const debugCacheDurationMs = 30 * 60 * 1000;
+
+interface DebugCacheEntry {
+  cachedAt: number;
+  response: unknown;
+}
+
+const inFlightRequests = new Map<string, Promise<unknown>>();
+
+function getDebugCachedResponse<Response>(url: string): Response | undefined {
+  const cache = StorageService.getMap<string, DebugCacheEntry>(StorageService.Keys.Codeforces.DebugApiCache, []);
+  const entry = cache.get(url);
+
+  if (entry === undefined) return undefined;
+  if (Date.now() - entry.cachedAt < debugCacheDurationMs) return entry.response as Response;
+
+  cache.delete(url);
+  StorageService.saveMap(StorageService.Keys.Codeforces.DebugApiCache, cache);
+  return undefined;
+}
+
+function saveDebugCachedResponse(url: string, response: unknown) {
+  const cache = StorageService.getMap<string, DebugCacheEntry>(StorageService.Keys.Codeforces.DebugApiCache, []);
+  const now = Date.now();
+
+  for (const [cachedUrl, entry] of cache) {
+    if (now - entry.cachedAt >= debugCacheDurationMs) cache.delete(cachedUrl);
+  }
+
+  cache.set(url, { cachedAt: now, response });
+  StorageService.saveMap(StorageService.Keys.Codeforces.DebugApiCache, cache);
+}
+
+async function fetchJson<Response>(url: string): Promise<Response> {
+  const response = await fetch(url);
+  return response.json() as Promise<Response>;
+}
+
+export function fetchCodeforcesApi<Response>(url: string): Promise<Response> {
+  if (!IS_DEBUG_MODE) return fetchJson<Response>(url);
+
+  const cachedResponse = getDebugCachedResponse<Response>(url);
+  if (cachedResponse !== undefined) {
+    console.log(`CFTracker is running in debug mode. Using cached Codeforces API response for ${url}.`);
+    return Promise.resolve(cachedResponse);
+  }
+
+  const inFlightRequest = inFlightRequests.get(url);
+  if (inFlightRequest !== undefined) return inFlightRequest as Promise<Response>;
+
+  console.log(`CFTracker is running in debug mode. Caching Codeforces API response for ${url} for 30 minutes.`);
+  const request = fetchJson<Response>(url)
+    .then((response) => {
+      saveDebugCachedResponse(url, response);
+      return response;
+    })
+    .finally(() => inFlightRequests.delete(url));
+
+  inFlightRequests.set(url, request);
+  return request;
+}

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,5 +1,3 @@
-export const CONTEST_FILTER = "contestFilter";
-export const PROBLEM_FILTER = "problemFilter";
 export const SOLVED_PROBLEMS = "solvedProblems";
 export const ATTEMPTED_PROBLEMS = "attemptedProblems";
 export const SOLVED_CONTESTS = "solvedContests";

--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -1,5 +1,6 @@
-export const BACKEND_API_URL = import.meta.env.VITE_BACKEND_API_URL
-export const GITHUB_OAUTH_CLIENT_ID = import.meta.env.VITE_GITHUB_OAUTH_CLIENT_ID
-export const GITHUB_OAUTH_REDIRECT_URI = import.meta.env.VITE_GITHUB_OAUTH_REDIRECT_URI
-export const IS_BACKEND_AVAILABLE = import.meta.env.VITE_IS_BACKEND_AVAILABLE
-export const BACKEND_NOT_AVAILBLE_MESSAGE = import.meta.env.VITE_BACKEND_NOT_AVAILBLE_MESSAGE
+export const BACKEND_API_URL = import.meta.env.VITE_BACKEND_API_URL;
+export const GITHUB_OAUTH_CLIENT_ID = import.meta.env.VITE_GITHUB_OAUTH_CLIENT_ID;
+export const GITHUB_OAUTH_REDIRECT_URI = import.meta.env.VITE_GITHUB_OAUTH_REDIRECT_URI;
+export const IS_BACKEND_AVAILABLE = import.meta.env.VITE_IS_BACKEND_AVAILABLE === "true";
+export const BACKEND_NOT_AVAILBLE_MESSAGE = import.meta.env.VITE_BACKEND_NOT_AVAILBLE_MESSAGE;
+export const IS_DEBUG_MODE = import.meta.env.DEV;

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -14,6 +14,14 @@ export function formateDate(time: number) {
 	);
 };
 
+export function formatDateInputValue(date: Date) {
+	const year = date.getFullYear().toString().padStart(4, "0");
+	const month = (date.getMonth() + 1).toString().padStart(2, "0");
+	const day = date.getDate().toString().padStart(2, "0");
+
+	return `${year}-${month}-${day}`;
+}
+
 export function getDaysInYear(year: number) {
 	return (year % 4 === 0 && year % 100 > 0) || year % 400 == 0 ? 366 : 365;
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -44,7 +44,7 @@ export const parseQuery = (queryString: string) => {
   return query;
 };
 
-export const processNumber = (
+export const clampNumber = (
   num: number,
   min: number,
   max: number


### PR DESCRIPTION
## Summary

This PR modernizes CFTracker across page architecture, persisted state, local development, statistics, and project documentation. The main refactor moves ProblemPage business logic into `useProblemPage` and keeps page components focused on composing reusable views.

## ProblemPage

- Move filtering, sorting, pagination, random selection, list operations, URL synchronization, and submission-derived state into `useProblemPage`.
- Split problem-table rendering into dedicated view components.
- Add persisted, open-ended contest-date filtering using contest start dates.
- Add a reusable native date-range control with clear and picker actions.
- Replace rating number fields with a persisted dual-thumb `800-3500` slider.
- Add an independent Unrated Problems filter.
- Normalize legacy rating bounds and keep range boundaries inclusive.
- Reuse `useContestStore` for contest-derived problem data.

## Stats and Data Loading

- Add a persisted All/year selector to the submissions heat map, defaulting to the latest available year.
- Show a simple empty state when no submission data is available.
- Hide contest-category charts that have no data.
- Remove the experimental Stats marker.
- Cache identical Codeforces API responses for 30 minutes in debug mode.
- Load the checked-in problem snapshot during local debug development and report that choice in the console.

## Shared Infrastructure

- Add `usePersistentState` for page-local state backed by `StorageService`.
- Centralize storage keys under `StorageService.Keys`.
- Add Set, Map, object, and primitive persistence through the existing serialization service.
- Add reusable date-range and dual-thumb range controls.
- Replace Contest random-selection `-1` sentinels with `undefined` and guard invalid indexes.
- Enable backend-backed features only when `VITE_IS_BACKEND_AVAILABLE` is explicitly `true`.

## Documentation

- Refresh the project overview and setup instructions.
- Add a dedicated development guide with frontend, backend, environment, data-refresh, and admin-tool workflows.
- Add contribution guidelines requiring an approved issue before implementation and pull-request submission.
- Document `manage-contests` as an owner/admin utility and list its required environment variables.

## Validation

- [x] `npm run build`
- [x] Focused TypeScript checks for the changed ProblemPage, Stats, Contest, and shared-control modules
- [x] Persistence compatibility for existing stored filter objects
- [x] Light and dark theme-specific slider styling

## Known Follow-up

A full `npx tsc -b` still reports pre-existing legacy issues in the unused CRA Web Vitals and Workbox service-worker files. Those issues are documented separately and are not introduced by this PR.