### PR TITLE
Dev

### DIFF
--- a/src/components/comment/CommentPage.tsx
+++ b/src/components/comment/CommentPage.tsx
@@ -2,7 +2,7 @@ import { useAppSelector } from "../../data/store";
 import { ThemesType } from "../../util/Theme";
 import UtterancesComments from "./UtterancesComments";
 
-const CommentPage = () => {
+function CommentPage() {
   const themeMod = useAppSelector((state) => state.appState.themeMod);
 
   return (
@@ -15,6 +15,6 @@ const CommentPage = () => {
       />
     </>
   );
-};
+}
 
 export default CommentPage;

--- a/src/components/comment/UtterancesComments.tsx
+++ b/src/components/comment/UtterancesComments.tsx
@@ -5,23 +5,25 @@ interface Props {
   theme: string;
 }
 
-const UtterancesComments: React.FC<Props> = (props: Props) => (
-  <section
-    ref={(elem) => {
-      if (!elem || elem.childNodes.length) {
-        return;
-      }
-      const scriptElem = document.createElement("script");
-      scriptElem.src = "https://utteranc.es/client.js";
-      scriptElem.async = true;
-      scriptElem.crossOrigin = "anonymous";
-      scriptElem.setAttribute("repo", props.repo);
-      scriptElem.setAttribute("issue-term", props.issue_term);
-      scriptElem.setAttribute("label", props.label);
-      scriptElem.setAttribute("theme", props.theme);
-      elem.appendChild(scriptElem);
-    }}
-  />
-);
+function UtterancesComments(props: Props) {
+  return (
+    <section
+      ref={(elem) => {
+        if (!elem || elem.childNodes.length) {
+          return;
+        }
+        const scriptElem = document.createElement("script");
+        scriptElem.src = "https://utteranc.es/client.js";
+        scriptElem.async = true;
+        scriptElem.crossOrigin = "anonymous";
+        scriptElem.setAttribute("repo", props.repo);
+        scriptElem.setAttribute("issue-term", props.issue_term);
+        scriptElem.setAttribute("label", props.label);
+        scriptElem.setAttribute("theme", props.theme);
+        elem.appendChild(scriptElem);
+      }}
+    />
+  );
+}
 
 export default UtterancesComments;

--- a/src/components/common/CustomModal.tsx
+++ b/src/components/common/CustomModal.tsx
@@ -17,11 +17,16 @@ interface PropsType {
   size?: "sm" | "lg" | "xl";
 }
 
-const CustomModal = (props: PropsType) => {
+function CustomModal(props: PropsType) {
   const [show, setShow] = useState(false);
 
-  const handleClose = () => setShow(false);
-  const handleShow = () => setShow(true);
+  function handleClose() {
+    setShow(false);
+  }
+
+  function handleShow() {
+    setShow(true);
+  }
 
   return (
     <>
@@ -45,6 +50,6 @@ const CustomModal = (props: PropsType) => {
       </Modal>
     </>
   );
-};
+}
 
 export default CustomModal;

--- a/src/components/common/Filter.tsx
+++ b/src/components/common/Filter.tsx
@@ -15,11 +15,15 @@ interface PropsType {
   setRandom: (num: number | undefined) => void;
   theme: Theme;
   name: string;
+  isRandomActive?: boolean;
 }
 
-const Filter = (props: PropsType) => {
-  let lo = props.selected * props.perPage;
-  let high = Math.min(props.length, lo + props.perPage);
+function Filter(props: PropsType) {
+  const isRandomActive = props.isRandomActive ?? false;
+  const lo = props.selected * props.perPage;
+  const high = Math.min(props.length, lo + props.perPage);
+  const visibleCount = isRandomActive ? Math.min(props.length, 1) : Math.max(0, high - lo);
+  const totalCount = isRandomActive ? visibleCount : props.length;
 
   return (
     <div className="menu">
@@ -38,7 +42,7 @@ const Filter = (props: PropsType) => {
           />
         </li>
         <li className="nav-item text-secondary">
-          Showing {high - lo} of {props.length}
+          Showing {visibleCount} of {totalCount}
         </li>
         <li className="nav-item">
           <div className="btn-group" role="group" aria-label="Basic example">
@@ -66,6 +70,6 @@ const Filter = (props: PropsType) => {
       </ul>
     </div>
   );
-};
+}
 
 export default Filter;

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -31,10 +31,11 @@ function Pagination(props: PaginationProps) {
   const displayPage = pageCount > 0 ? selected + 1 : 0;
   const isRandomModeDisabled = isRandomActive;
   const isPageNavigationDisabled = isRandomModeDisabled || pageCount <= 1;
+  const isPageSizeDisabled = isRandomModeDisabled || pageCount === 0;
 
   useEffect(() => {
     if (isLoading || isRandomActive) return;
-    if (props.selected < 0 || (props.selected >= pageCount && props.selected !== 0)) props.pageSelected(0);
+    if (props.selected >= pageCount && props.selected !== 0 && pageCount !== 0) props.pageSelected(0);
   }, [isLoading, isRandomActive, pageCount, props.pageSelected, props.selected]);
 
   const pageSizeOptions = useMemo(() => {
@@ -96,7 +97,7 @@ function Pagination(props: PaginationProps) {
               textClass={props.theme.bgText}
               inputClass={props.theme.bgText}
               onChange={(e) => {
-                if (isRandomModeDisabled) return;
+                if (isRandomModeDisabled || isLoading) return;
                 props.pageSelected(e - 1);
               }}
               disabled={isPageNavigationDisabled}
@@ -114,7 +115,7 @@ function Pagination(props: PaginationProps) {
               <select
                 className={"custom-select " + props.theme.bgText}
                 value={isRandomActive ? 1 : props.perPage}
-                disabled={isRandomModeDisabled}
+                disabled={isPageSizeDisabled}
                 onChange={(e) => {
                   if (props.pageSize) {
                     props.pageSize(clampNumber(parseInt(e.target.value), 1, props.totalCount));

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import Theme from "../../util/Theme";
 import { clampNumber } from "../../util/util";
 import InputNumber from "./forms/Input/InputNumber";
@@ -11,12 +11,14 @@ interface PaginationProps {
   totalCount: number;
   theme: Theme;
   isRandomActive?: boolean;
+  isLoading?: boolean;
 }
 
 function Pagination(props: PaginationProps) {
   let linkClassName = "page-link " + props.theme.bgText;
   let linkWrapperClassName = "page-item";
   const isRandomActive = props.isRandomActive ?? false;
+  const isLoading = props.isLoading ?? false;
   const effectiveTotalCount = isRandomActive ? Math.min(props.totalCount, 1) : props.totalCount;
 
   let pageCount =
@@ -29,6 +31,11 @@ function Pagination(props: PaginationProps) {
   const displayPage = pageCount > 0 ? selected + 1 : 0;
   const isRandomModeDisabled = isRandomActive;
   const isPageNavigationDisabled = isRandomModeDisabled || pageCount <= 1;
+
+  useEffect(() => {
+    if (isLoading || isRandomActive) return;
+    if (props.selected < 0 || (props.selected >= pageCount && props.selected !== 0)) props.pageSelected(0);
+  }, [isLoading, isRandomActive, pageCount, props.pageSelected, props.selected]);
 
   const pageSizeOptions = useMemo(() => {
     if (isRandomActive) return [1];

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -10,36 +10,47 @@ interface PaginationProps {
   pageSize?: (size: number) => void;
   totalCount: number;
   theme: Theme;
+  isRandomActive?: boolean;
 }
 
-const Pagination = (props: PaginationProps) => {
+function Pagination(props: PaginationProps) {
   let linkClassName = "page-link " + props.theme.bgText;
   let linkWrapperClassName = "page-item";
+  const isRandomActive = props.isRandomActive ?? false;
+  const effectiveTotalCount = isRandomActive ? Math.min(props.totalCount, 1) : props.totalCount;
 
   let pageCount =
     props.perPage > 0
-      ? Math.floor((Math.floor(props.totalCount) + Math.floor(props.perPage) - 1) / Math.floor(props.perPage))
+      ? Math.floor((Math.floor(effectiveTotalCount) + Math.floor(props.perPage) - 1) / Math.floor(props.perPage))
       : 0;
+  const selected = pageCount > 0 ? clampNumber(props.selected, 0, pageCount - 1) : 0;
+  const canGoPrevious = !isRandomActive && pageCount > 0 && selected > 0;
+  const canGoNext = !isRandomActive && pageCount > 0 && selected < pageCount - 1;
+  const displayPage = pageCount > 0 ? selected + 1 : 0;
+  const isRandomModeDisabled = isRandomActive;
+  const isPageNavigationDisabled = isRandomModeDisabled || pageCount <= 1;
 
   const pageSizeOptions = useMemo(() => {
+    if (isRandomActive) return [1];
+
     let sizes = [10, 20, 50, 100];
     if (!sizes.includes(props.totalCount)) sizes.push(props.totalCount);
     return sizes;
-  }, [props.totalCount]);
+  }, [isRandomActive, props.totalCount]);
 
   return (
     <nav aria-label="Page navigation example d-flex justify-content-center" style={{ height: "50px" }}>
       <ul className="pagination m-0 d-flex justify-content-center">
         <li className={linkWrapperClassName}>
-          <button className={linkClassName} onClick={() => props.pageSelected(0)} aria-disabled={props.selected === 0}>
+          <button className={linkClassName} onClick={() => props.pageSelected(0)} disabled={!canGoPrevious} aria-disabled={!canGoPrevious}>
             {"<<"}
           </button>
         </li>
         <li className={linkWrapperClassName}>
           <button
             className={linkClassName}
-            onClick={() => props.pageSelected(props.selected - 1)}
-            disabled={props.selected === 0}
+            onClick={() => props.pageSelected(selected - 1)}
+            disabled={!canGoPrevious}
           >
             {"<"}
           </button>
@@ -47,8 +58,8 @@ const Pagination = (props: PaginationProps) => {
         <li className={linkWrapperClassName}>
           <button
             className={linkClassName}
-            onClick={() => props.pageSelected(props.selected + 1)}
-            disabled={props.selected === pageCount - 1}
+            onClick={() => props.pageSelected(selected + 1)}
+            disabled={!canGoNext}
           >
             {">"}
           </button>
@@ -57,14 +68,14 @@ const Pagination = (props: PaginationProps) => {
           <button
             className={linkClassName}
             onClick={() => props.pageSelected(pageCount - 1)}
-            disabled={props.selected === pageCount - 1}
+            disabled={!canGoNext}
           >
             {">>"}
           </button>
         </li>
         <li className={linkWrapperClassName + " p-2"}>
           <span>
-            Page {props.selected + 1} of {pageCount}
+            Page {displayPage} of {pageCount}
           </span>
         </li>
         <li className={linkWrapperClassName}>
@@ -72,14 +83,16 @@ const Pagination = (props: PaginationProps) => {
             <InputNumber
               header={"Go to page:"}
               name={"gotoPage"}
-              value={props.selected + 1}
+              value={displayPage}
               min={1}
               max={pageCount}
               textClass={props.theme.bgText}
               inputClass={props.theme.bgText}
               onChange={(e) => {
+                if (isRandomModeDisabled) return;
                 props.pageSelected(e - 1);
               }}
+              disabled={isPageNavigationDisabled}
             />
           </div>
         </li>
@@ -93,7 +106,8 @@ const Pagination = (props: PaginationProps) => {
               </div>
               <select
                 className={"custom-select " + props.theme.bgText}
-                value={props.perPage}
+                value={isRandomActive ? 1 : props.perPage}
+                disabled={isRandomModeDisabled}
                 onChange={(e) => {
                   if (props.pageSize) {
                     props.pageSize(clampNumber(parseInt(e.target.value), 1, props.totalCount));
@@ -112,6 +126,6 @@ const Pagination = (props: PaginationProps) => {
       </ul>
     </nav>
   );
-};
+}
 
 export default Pagination;

--- a/src/components/common/forms/Input/InputChecked.tsx
+++ b/src/components/common/forms/Input/InputChecked.tsx
@@ -13,7 +13,7 @@ interface PropsType {
   className?: string;
 }
 
-const InputChecked = (props: PropsType) => {
+function InputChecked(props: PropsType) {
   return (
     <InputGroup className={"d-flex " + (props.className ? props.className : "")} title={props.title}>
       <InputGroup.Text className={props.textClass + " " + props.theme.bgText}>{props.header}</InputGroup.Text>
@@ -40,6 +40,6 @@ const InputChecked = (props: PropsType) => {
       </div>
     </InputGroup>
   );
-};
+}
 
 export default InputChecked;

--- a/src/components/common/forms/Input/InputNumber.tsx
+++ b/src/components/common/forms/Input/InputNumber.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 interface PropsType {
   header: string;
@@ -19,6 +19,7 @@ const INPUT_RESET_DELAY_MS = 500;
 
 function InputNumber(props: PropsType) {
   const [inputValue, setInputValue] = useState<string>(props.value.toString());
+  const latestProps = useRef({ value: props.value, min: props.min, max: props.max });
 
   function validateAndUpdate() {
     let num: number = parseInt(inputValue);
@@ -27,15 +28,20 @@ function InputNumber(props: PropsType) {
       return window.setTimeout(() => {
         setInputValue((currentInputValue) => {
           const currentNumber = parseInt(currentInputValue);
-          return !isNaN(currentNumber) && isOutsideRange(currentNumber) ? props.value.toString() : currentInputValue;
+          return !isNaN(currentNumber) && isOutsideRange(currentNumber) ? latestProps.current.value.toString() : currentInputValue;
         });
       }, INPUT_RESET_DELAY_MS);
     if (num !== props.value) props.onChange(num);
   }
 
   function isOutsideRange(num: number) {
-    return num < props.min || num > props.max;
+    return num < latestProps.current.min || num > latestProps.current.max;
   }
+
+  useEffect(() => {
+    latestProps.current = { value: props.value, min: props.min, max: props.max };
+  }, [props.value, props.min, props.max]);
+
   useEffect(() => {
     setInputValue(props.value.toString());
   }, [props.value]);

--- a/src/components/common/forms/Input/InputNumber.tsx
+++ b/src/components/common/forms/Input/InputNumber.tsx
@@ -13,12 +13,13 @@ interface PropsType {
   title?: string;
   step?: number;
   className?: string;
+  disabled?: boolean;
 }
 
-const InputNumber = (props: PropsType) => {
+function InputNumber(props: PropsType) {
   const [inputValue, setInputValue] = useState<string>(props.value.toString());
 
-  const validateAndUpdate = () => {
+  function validateAndUpdate() {
     let num: number = parseInt(inputValue);
     if (!isNaN(num)) {
       let clampedNumber = clampNumber(num, props.min, props.max);
@@ -28,7 +29,7 @@ const InputNumber = (props: PropsType) => {
       }
       props.onChange(num);
     }
-  };
+  }
 
   const firstTime = useRef(true);
   useEffect(() => {
@@ -56,10 +57,11 @@ const InputNumber = (props: PropsType) => {
         value={inputValue}
         name={props.name}
         step={props.step ? props.step : 1}
+        disabled={props.disabled}
         onChange={(e) => setInputValue(e.target.value)}
       />
     </div>
   );
-};
+}
 
 export default InputNumber;

--- a/src/components/common/forms/Input/InputNumber.tsx
+++ b/src/components/common/forms/Input/InputNumber.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect, useRef } from "react";
-import { clampNumber } from "../../../../util/util";
+import { useState, useEffect } from "react";
 
 interface PropsType {
   header: string;
@@ -16,25 +15,36 @@ interface PropsType {
   disabled?: boolean;
 }
 
+const INPUT_RESET_DELAY_MS = 500;
+
 function InputNumber(props: PropsType) {
   const [inputValue, setInputValue] = useState<string>(props.value.toString());
 
   function validateAndUpdate() {
     let num: number = parseInt(inputValue);
-    if (!isNaN(num)) {
-      let clampedNumber = clampNumber(num, props.min, props.max);
-      if (clampedNumber != num) {
-        // FIXME:- It causes infinite rendering
-        // setInputValue(clampedNumber.toString()); // converting num to string
-      }
-      props.onChange(num);
-    }
+    if (isNaN(num)) return;
+    if (isOutsideRange(num))
+      return window.setTimeout(() => {
+        setInputValue((currentInputValue) => {
+          const currentNumber = parseInt(currentInputValue);
+          return !isNaN(currentNumber) && isOutsideRange(currentNumber) ? props.value.toString() : currentInputValue;
+        });
+      }, INPUT_RESET_DELAY_MS);
+    if (num !== props.value) props.onChange(num);
   }
 
-  const firstTime = useRef(true);
+  function isOutsideRange(num: number) {
+    return num < props.min || num > props.max;
+  }
   useEffect(() => {
-    if (firstTime.current) firstTime.current = false;
-    else validateAndUpdate();
+    setInputValue(props.value.toString());
+  }, [props.value]);
+
+  useEffect(() => {
+    const timeoutId = validateAndUpdate();
+    return () => {
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+    };
   }, [inputValue]);
 
   return (
@@ -51,12 +61,14 @@ function InputNumber(props: PropsType) {
         {props.header}
       </span>
       <input
-        className={"form-control " + (props.inputClass || "")}
+        className={"form-control " + (props.inputClass ?? "")}
         type="number"
         placeholder="Max Rating"
         value={inputValue}
         name={props.name}
-        step={props.step ? props.step : 1}
+        min={props.min}
+        max={props.max}
+        step={props.step ?? 1}
         disabled={props.disabled}
         onChange={(e) => setInputValue(e.target.value)}
       />

--- a/src/components/common/forms/Input/InputRange.tsx
+++ b/src/components/common/forms/Input/InputRange.tsx
@@ -16,7 +16,7 @@ interface PropsType {
   theme: Theme;
 }
 
-const InputRange = (props: PropsType) => {
+function InputRange(props: PropsType) {
   return (
     <div className={"d-flex " + (props.className ? props.className : "")}>
       <InputNumber
@@ -51,6 +51,6 @@ const InputRange = (props: PropsType) => {
       />
     </div>
   );
-};
+}
 
 export default InputRange;

--- a/src/components/common/tooltip/Tooltip.tsx
+++ b/src/components/common/tooltip/Tooltip.tsx
@@ -8,7 +8,7 @@ type TooltipProps = {
   height: number;
 };
 
-export const Tooltip = ({ children, width, height, xPosition, yPosition }: TooltipProps) => {
+export function Tooltip({ children, width, height, xPosition, yPosition }: TooltipProps) {
   if (!children) {
     return null;
   }
@@ -38,4 +38,4 @@ export const Tooltip = ({ children, width, height, xPosition, yPosition }: Toolt
       </div>
     </div>
   );
-};
+}

--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -21,6 +21,7 @@ function ContestPage() {
     allParticipantType,
     participant,
     currentPageContests,
+    isPaginationLoading,
     isRandomActive,
     selectableVerdictStatuses,
     categoryFilter,
@@ -160,13 +161,14 @@ function ContestPage() {
       </div>
       <footer className={"pt-2 " + theme.bg}>
         <Pagination
-          pageSelected={(e) => setSelected(e)}
+          pageSelected={setSelected}
           perPage={filter.perPage}
           selected={selected}
           theme={theme}
           totalCount={contestList.contests.length}
           pageSize={(e) => updateFilter({ perPage: e })}
           isRandomActive={isRandomActive}
+          isLoading={isPaginationLoading}
         />
       </footer>
     </>

--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -21,6 +21,7 @@ function ContestPage() {
     allParticipantType,
     participant,
     currentPageContests,
+    isRandomActive,
     selectableVerdictStatuses,
     categoryFilter,
     updateFilter,
@@ -48,6 +49,7 @@ function ContestPage() {
           name="Contest"
           setRandom={setRandomContest}
           theme={theme}
+          isRandomActive={isRandomActive}
         >
           <CustomModal title="filter" theme={theme}>
             <div className="group">
@@ -147,7 +149,7 @@ function ContestPage() {
                     showDate={filter.showDate}
                     showRating={filter.showRating}
                     perPage={filter.perPage}
-                    pageSelected={selected}
+                    pageSelected={isRandomActive ? 0 : selected}
                     theme={theme}
                   />
                 )}
@@ -164,6 +166,7 @@ function ContestPage() {
           theme={theme}
           totalCount={contestList.contests.length}
           pageSize={(e) => updateFilter({ perPage: e })}
+          isRandomActive={isRandomActive}
         />
       </footer>
     </>

--- a/src/components/contest/ContestPage.tsx
+++ b/src/components/contest/ContestPage.tsx
@@ -42,6 +42,7 @@ function ContestPage() {
           searchName="searchContest"
           searchPlaceHolder="Search by Contest Name or Id"
           onSearch={(e) => {
+            setSelected(0);
             updateFilter({ search: e });
           }}
           length={contestList.contests.length}

--- a/src/components/contest/useContestPage.ts
+++ b/src/components/contest/useContestPage.ts
@@ -51,7 +51,6 @@ function useContestPage() {
 		contests: Contest[];
 		error: string;
 	}>({ contests: [], error: "" });
-	const [isPaginationLoading, setIsPaginationLoading] = useState(true);
 
 	const [randomContest, setRandomContest] = useState<number | undefined>(undefined);
 
@@ -82,6 +81,7 @@ function useContestPage() {
 	const allParticipantType = useMemo(() => Object.keys(ParticipantType), []);
 
 	const [selected, setSelected] = usePersistentState(StorageService.Keys.Contest.Page, 0);
+	const isPaginationLoading = problemList.loading || isContestListLoading;
 	const [solveStatus, setSolveStatus] = useState(
 		StorageService.getSet(StorageService.Keys.Contest.SolveStatus, selectableVerdictStatuses)
 	);
@@ -98,9 +98,7 @@ function useContestPage() {
 		let high = Math.min(contestList.contests.length, lo + filter.perPage);
 
 		if (lo > high) return [];
-		console.log("CurrentPageContests ", randomContest, lo, high);
-		// return contestList.contests.slice(lo, high);
-		return getCurrentPageContests();
+		return contestList.contests.slice(lo, high);
 	}, [contestList, selected, filter.perPage, randomContest]);
 
 	const submissions = useMemo(() => {
@@ -139,14 +137,6 @@ function useContestPage() {
 		return status && searchIncluded && contest.count !== 0 && catIn;
 	};
 
-	function getCurrentPageContests() {
-		let lo = selected * filter.perPage;
-		let high = Math.min(contestList.contests.length, lo + filter.perPage);
-
-		if (lo > high) return [];
-		return contestList.contests.slice(lo, high);
-	}
-
 	useEffect(() => {
 		StorageService.saveObject(StorageService.Keys.Contest.Filter, filter);
 		if (filter.search.trim().length) updateSearchParam(SearchKeys.Search, filter.search.trim());
@@ -156,8 +146,7 @@ function useContestPage() {
 
 		setContestList({ ...contestList, contests: newContestList });
 		setRandomContest(undefined);
-		setIsPaginationLoading(problemList.loading || isContestListLoading);
-	}, [contests, filter, problemList.loading, problemList.problems, solveStatus, submissions, isContestListLoading]);
+	}, [contests, filter, problemList.problems, solveStatus, submissions]);
 
 	useEffect(() => {
 		if (!filter.canSelectMultipleCategories && filter.selectedCategories.length !== 1) {

--- a/src/components/contest/useContestPage.ts
+++ b/src/components/contest/useContestPage.ts
@@ -11,6 +11,7 @@ import { ParticipantType } from "../../types/CF/Party";
 import useContestStore from "../../data/hooks/useContestStore";
 import { isDefined, isFunction, overrideObject } from "../../util/util";
 import useProblemsStore from "../../data/hooks/useProblemsStore";
+import usePersistentState from "../../hooks/usePersistentState";
 
 export interface Filter {
 	perPage: number;
@@ -50,6 +51,7 @@ function useContestPage() {
 		contests: Contest[];
 		error: string;
 	}>({ contests: [], error: "" });
+	const [isPaginationLoading, setIsPaginationLoading] = useState(true);
 
 	const [randomContest, setRandomContest] = useState<number | undefined>(undefined);
 
@@ -79,7 +81,7 @@ function useContestPage() {
 
 	const allParticipantType = useMemo(() => Object.keys(ParticipantType), []);
 
-	const [selected, setSelected] = useState(0);
+	const [selected, setSelected] = usePersistentState(StorageService.Keys.Contest.Page, 0);
 	const [solveStatus, setSolveStatus] = useState(
 		StorageService.getSet(StorageService.Keys.Contest.SolveStatus, selectableVerdictStatuses)
 	);
@@ -154,18 +156,15 @@ function useContestPage() {
 
 		setContestList({ ...contestList, contests: newContestList });
 		setRandomContest(undefined);
-	}, [contests, filter, problemList.problems, solveStatus, submissions]);
+		setIsPaginationLoading(problemList.loading || isContestListLoading);
+	}, [contests, filter, problemList.loading, problemList.problems, solveStatus, submissions, isContestListLoading]);
 
 	useEffect(() => {
-		if (!filter.canSelectMultipleCategories) {
+		if (!filter.canSelectMultipleCategories && filter.selectedCategories.length !== 1) {
 			let newSelectedCategory = filter.selectedCategories.length === 0 ? ContestCat.DIV2 : filter.selectedCategories[0];
 			updateFilter({ selectedCategories: [newSelectedCategory] });
 		}
-	}, [filter.canSelectMultipleCategories]);
-
-	useEffect(() => {
-		setSelected(0);
-	}, [filter.selectedCategories]);
+	}, [filter.canSelectMultipleCategories, filter.selectedCategories]);
 
 	function updateSolveStatus(status: Set<Verdict>) {
 		setSolveStatus(status);
@@ -206,6 +205,7 @@ function useContestPage() {
 		allParticipantType,
 		participant,
 		currentPageContests,
+		isPaginationLoading,
 		isRandomActive: randomContest !== undefined,
 		selectableVerdictStatuses,
 		categoryFilter,

--- a/src/components/contest/useContestPage.ts
+++ b/src/components/contest/useContestPage.ts
@@ -206,6 +206,7 @@ function useContestPage() {
 		allParticipantType,
 		participant,
 		currentPageContests,
+		isRandomActive: randomContest !== undefined,
 		selectableVerdictStatuses,
 		categoryFilter,
 		updateFilter,

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -2,13 +2,13 @@ import { useNavigate } from "react-router";
 import { Path } from "../../util/route/path";
 import { useEffect } from "react";
 
-const HomePage = () => {
+function HomePage() {
   const navigate = useNavigate();
   useEffect(() => {
     navigate(Path.CONTESTS);
   }, []);
 
   return <div className="container"></div>;
-};
+}
 
 export default HomePage;

--- a/src/components/problem/ProblemPage.tsx
+++ b/src/components/problem/ProblemPage.tsx
@@ -42,7 +42,10 @@ function ProblemPage() {
           searchName="problemSearch"
           searchPlaceHolder="Problem Name or Id"
           name="Problem"
-          onSearch={(search) => updateFilter({ search })}
+          onSearch={(search) => {
+            setSelected(0);
+            updateFilter({ search });
+          }}
           length={problemList.problems.length}
           perPage={filter.perPage}
           selected={selected}

--- a/src/components/problem/ProblemPage.tsx
+++ b/src/components/problem/ProblemPage.tsx
@@ -5,7 +5,7 @@ import ProblemFilterModal from "./ProblemFilterModal";
 import ProblemTable from "./problem-list/ProblemTable";
 import useProblemPage from "./useProblemPage";
 
-const ProblemPage = () => {
+function ProblemPage() {
   const {
     state,
     theme,
@@ -23,6 +23,7 @@ const ProblemPage = () => {
     selectableVerdictStatuses,
     showAddToList,
     problemsAddedToList,
+    isRandomActive,
     updateFilter,
     setSelected,
     setSolveStatus,
@@ -47,6 +48,7 @@ const ProblemPage = () => {
           selected={selected}
           setRandom={setRandomProblem}
           theme={theme}
+          isRandomActive={isRandomActive}
         >
           <ProblemFilterModal
             theme={theme}
@@ -73,7 +75,7 @@ const ProblemPage = () => {
                 solved={solved}
                 attempted={attempted}
                 perPage={filter.perPage}
-                pageSelected={selected}
+                pageSelected={isRandomActive ? 0 : selected}
                 theme={theme}
                 filterState={filterState}
                 showAddToList={showAddToList}
@@ -96,10 +98,11 @@ const ProblemPage = () => {
           theme={theme}
           pageSelected={(page) => setSelected(page)}
           pageSize={(perPage) => updateFilter({ perPage })}
+          isRandomActive={isRandomActive}
         />
       </footer>
     </>
   );
-};
+}
 
 export default ProblemPage;

--- a/src/components/problem/ProblemPage.tsx
+++ b/src/components/problem/ProblemPage.tsx
@@ -96,9 +96,10 @@ function ProblemPage() {
           perPage={filter.perPage}
           selected={selected}
           theme={theme}
-          pageSelected={(page) => setSelected(page)}
+          pageSelected={setSelected}
           pageSize={(perPage) => updateFilter({ perPage })}
           isRandomActive={isRandomActive}
+          isLoading={state.problemList.loading}
         />
       </footer>
     </>

--- a/src/components/problem/useProblemPage.ts
+++ b/src/components/problem/useProblemPage.ts
@@ -336,6 +336,7 @@ function useProblemPage() {
 		selectableVerdictStatuses,
 		showAddToList: isDefined(listId),
 		problemsAddedToList,
+		isRandomActive: randomProblem !== undefined,
 		updateFilter,
 		setSelected,
 		setSolveStatus: updateSolveStatus,

--- a/src/components/problem/useProblemPage.ts
+++ b/src/components/problem/useProblemPage.ts
@@ -109,7 +109,7 @@ function useProblemPage() {
 		defaultSolveStatus
 	);
 	const [randomProblem, setRandomProblem] = useState<number | undefined>(undefined);
-	const [selected, setSelected] = useState(0);
+	const [selected, setSelected] = usePersistentState(StorageService.Keys.Problem.Page, 0);
 
 	const filterState = useMemo<ProblemFilterState>(
 		() => ({
@@ -256,7 +256,6 @@ function useProblemPage() {
 
 	useEffect(() => {
 		setRandomProblem(undefined);
-		setSelected(0);
 	}, [filteredProblems]);
 
 	const updateFilter = useCallback((value: UpdateProblemFilter) => {

--- a/src/components/stats/StatPage.tsx
+++ b/src/components/stats/StatPage.tsx
@@ -10,7 +10,7 @@ import useStatPage from "./useStatPage";
  * percentage of problem solved by problem index
  * percentage of problem solved by rating
  */
-const StatPage = () => {
+function StatPage() {
   const { problemIDsBySimpleVerdict, submissionsByVerdict, hasSubmissionData } = useStatPage();
 
   if (!hasSubmissionData) {
@@ -36,6 +36,6 @@ const StatPage = () => {
       </div>
     </div>
   );
-};
+}
 
 export default StatPage;

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -10,6 +10,9 @@ import { StorageService } from '../util/StorageService';
 import { listApi } from './queries/listQuery';
 import { codeforcesApi } from './queries/codeforcesQuery';
 import { userSubmissionsListener } from './listeners/userSubmissionsListener';
+import { IS_DEBUG_MODE } from '../util/env';
+
+const IS_REDUX_LOGGING_ENABLED = IS_DEBUG_MODE || sessionStorage.getItem("redux-debug") === "true";
 
 const rootReducer = combineReducers({
   appState: appSlice,
@@ -46,10 +49,11 @@ function loadFromLocalStorage(): any {
 
 const store = configureStore({
   reducer: rootReducer,
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware()
-    .prepend(userSubmissionsListener.middleware)
-    .concat(logger)
-    .concat([userApi.middleware, listApi.middleware, codeforcesApi.middleware]),
+  middleware: (getDefaultMiddleware) => {
+    const middleware = getDefaultMiddleware().prepend(userSubmissionsListener.middleware);
+    if (IS_REDUX_LOGGING_ENABLED) middleware.push(logger);
+    return middleware.concat([userApi.middleware, listApi.middleware, codeforcesApi.middleware]);
+  },
   preloadedState: loadFromLocalStorage()
 });
 

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -20,7 +20,7 @@ const rootReducer = combineReducers({
   [codeforcesApi.reducerPath]: codeforcesApi.reducer
 });
 
-const saveToLocalStorage = (state: RootState) => {
+function saveToLocalStorage(state: RootState) {
   try {
     const newState = {
       userList: state.userList,
@@ -30,9 +30,9 @@ const saveToLocalStorage = (state: RootState) => {
   } catch (e) {
     console.log(e);
   }
-};
+}
 
-const loadFromLocalStorage = (): any => {
+function loadFromLocalStorage(): any {
   try {
     const persedData = StorageService.getObject(StorageService.Keys.StateV2, {});
 
@@ -42,7 +42,7 @@ const loadFromLocalStorage = (): any => {
     console.log(e);
     return {};
   }
-};
+}
 
 const store = configureStore({
   reducer: rootReducer,

--- a/src/hooks/usePageTracking.tsx
+++ b/src/hooks/usePageTracking.tsx
@@ -2,13 +2,13 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import ReactGA from "react-ga4";
 
-const usePageTracking = () => {
+function usePageTracking() {
   const location = useLocation();
 
   useEffect(() => {
     ReactGA.initialize("G-0DNH915N52");
     ReactGA.send({ hitType: "pageview", page: location.pathname, title: location.pathname + location.search });
   }, [location.pathname, location.search]);
-};
+}
 
 export default usePageTracking;

--- a/src/util/StorageService.ts
+++ b/src/util/StorageService.ts
@@ -3,11 +3,13 @@ const Keys = {
   StateV2: "statev2",
   Problem: {
     Filter: "PROBLEM_FILTER",
+    Page: "PROBLEM_PAGE",
     Tags: "PROBLEM_TAGS",
     SolveStatus: "PROBLEM_SOLVE_STATUS",
   },
   Contest: {
     Filter: "CONTEST_FILTER",
+    Page: "CONTEST_PAGE",
     SolveStatus: "CONTEST_SOLVE_STATUS",
     ParticipantType: "PARTICIPANT_TYPE",
   },

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,45 +1,45 @@
 /** Returns the Codeforces contest page URL for a contest id. */
-export const getContestUrl = (contestId: number) => {
+export function getContestUrl(contestId: number) {
   return "https://codeforces.com/contest/" + contestId;
-};
+}
 
 /** Returns the Codeforces problem page URL for a contest id and problem index. */
-export const getProblemUrl = (contestId: number, index: string) => {
+export function getProblemUrl(contestId: number, index: string) {
   return getContestUrl(contestId) + "/problem/" + index;
-};
+}
 
 /** Returns the Codeforces user submissions API URL, optionally limited by count. */
-export const getUserSubmissionsURL = (handle: string, limit?: number) => {
+export function getUserSubmissionsURL(handle: string, limit?: number) {
   return (
     "https://codeforces.com/api/user.status?handle=" +
     handle +
     (limit ? "&&from=1&count=" + limit : "")
   );
-};
+}
 
 /** Returns the Codeforces user info API URL for one or more comma-separated handles. */
-export const getUserInfoURL = (handle: string) => {
+export function getUserInfoURL(handle: string) {
   handle = handle.trim().replace(/,/g, ";");
   return "https://codeforces.com/api/user.info?handles=" + handle;
-};
+}
 
 /** Splits a trimmed string by the provided separator. */
-export const stringToArray = (s: string, separator: string): string[] => {
+export function stringToArray(s: string, separator: string): string[] {
   return s.trim().split(separator);
-};
+}
 
 /** Returns the character shifted by the given character-code offset. */
-export const increment = (char: string, by: number) => {
+export function increment(char: string, by: number) {
   return String.fromCharCode(char.charCodeAt(0) + by);
-};
+}
 
 /** Returns a random integer in the half-open range [min, max). */
-export const getRandomInteger = (min: number, max: number) => {
+export function getRandomInteger(min: number, max: number) {
   return Math.floor(Math.random() * (max - min)) + min;
-};
+}
 
 /** Parses a query string into a key-value object. */
-export const parseQuery = (queryString: string) => {
+export function parseQuery(queryString: string) {
   queryString = queryString.trim();
   var query: Record<string, string> = {};
   var pairs = (
@@ -50,19 +50,19 @@ export const parseQuery = (queryString: string) => {
     query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || "");
   }
   return query;
-};
+}
 
 /** Restricts a number to the inclusive min/max bounds, using min for NaN. */
-export const clampNumber = (
+export function clampNumber(
   num: number,
   min: number,
   max: number
-): number => {
+): number {
   if (isNaN(num)) return min;
   if (num < min) return min;
   if (num > max) return max;
   return num;
-};
+}
 
 /**
  * 


### PR DESCRIPTION
## Summary

- Make shared filtering and pagination aware of random mode so counts, page numbering, row numbering, and navigation match the single displayed item.
- Persist the selected page independently for problems and contests, validate out-of-range saved pages after loading, and reset to the first page for searches entered in the app.
- Improve numeric input synchronization and bounds handling, including a debounced reset for out-of-range values.
- Disable unavailable pagination controls while random mode is active or no pages are available.
- Gate Redux action logging behind debug mode or a session-level `redux-debug=true` opt-in.
- Standardize frontend component and utility declarations as traditional functions.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Netlify deploy previews passed for both configured sites.
