### PR TITLE
Fix form label associations and add Git contribution guidance

### DIFF
--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: commit-and-pr
+description: CFTracker commit and pull-request conventions. Use whenever Codex creates or amends a commit, or creates or updates a pull request in this repository.
+---
+
+# Commits And Pull Requests
+
+## Commits
+
+- Review the status and staged diff before committing, and include only the intended changes.
+- Give every Codex-created or Codex-amended commit a clear imperative subject and a concise body describing the meaningful changes, reasons, and relevant verification.
+- End the commit message, after a blank line, with this trailer:
+
+```text
+Co-authored-by: Codex (XX%) <noreply@openai.com>
+```
+
+- Replace `XX` with a good-faith whole-number estimate of Codex's contribution to that commit. Estimate the commit itself, not the entire branch or conversation.
+- Keep the email address unchanged so GitHub associates the commit with the Codex account.
+- Count all requirements, instructions, constraints, design guidance, review feedback, corrections, and manually written or edited code, tests, and documentation as human contribution.
+- Count only independent analysis, decisions, implementation, tests, documentation, and verification actually produced by Codex as Codex contribution. Do not estimate authorship from changed-line counts alone or inflate it for formatting, tool execution, staging, or commit mechanics.
+- Do not rewrite an existing commit solely to add or alter the trailer unless the user requests an amendment.
+
+## Pull Requests
+
+- Before creating a PR, check whether one already exists for the current branch and update it instead of creating a duplicate.
+- For a new PR, use `main` as the base branch and the currently checked-out branch as the head unless the user specifies otherwise.
+- Keep the current branch checked out after creating or updating the PR. If a temporary checkout is unavoidable, restore the original branch before finishing.
+- Derive the title and description from the complete base-to-head diff. Summarize the behavior, verification, and important operational or review notes rather than describing only the latest commit.
+- Assign the PR to both the requesting human and the repository-configured Codex GitHub identity. Verify that each identity is assignable; if GitHub rejects either one, assign every valid identity and explicitly report the missing assignment without guessing or substituting another account.

--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -8,7 +8,8 @@ description: CFTracker commit and pull-request conventions. Use whenever Codex c
 ## Commits
 
 - Review the status and staged diff before committing, and include only the intended changes.
-- Give every Codex-created or Codex-amended commit a clear imperative subject and a concise body describing the meaningful changes, reasons, and relevant verification.
+- Follow the commit-message policy in `CONTRIBUTING.md`; treat it as the source of truth for subject format and type selection.
+- Give every Codex-created or Codex-amended commit a concise body describing the meaningful changes, reasons, and relevant verification.
 - End the commit message, after a blank line, with this trailer:
 
 ```text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,13 +88,40 @@ make test
 
 ## Commit Messages
 
-Use clear, imperative commit messages:
+Use this Conventional Commit format:
 
 ```text
-Refactor problem page into hook and views
-Fix contest category multiselect reset
-Document backend setup
+<type>(<optional-scope>): <imperative summary>
 ```
+
+Allowed types:
+
+- `feat`: Add or change user-facing behavior.
+- `fix`: Correct a defect, security issue, or unintended behavior.
+- `refactor`: Restructure code without changing its behavior.
+- `perf`: Improve performance without changing behavior.
+- `test`: Change tests, fixtures, or test infrastructure only.
+- `docs`: Change documentation only.
+- `build`: Change dependencies, build tooling, or packaging.
+- `ci`: Change continuous-integration or delivery automation.
+- `chore`: Perform repository maintenance that does not fit another type.
+- `revert`: Revert an earlier commit.
+
+Choose the type from the commit's primary purpose. Tests and documentation that support a feature or fix belong in that `feat` or `fix` commit; use `test` or `docs` when they are the commit's main purpose. Split unrelated purposes into separate commits.
+
+Begin the summary with a lowercase imperative verb, keep it no longer than 72 characters, and omit the final period. Preserve the normal capitalization of proper nouns such as GitHub and OAuth. Use a short lowercase scope only when it adds useful context. Add a body after a blank line when the reason, behavior, or verification is not clear from the subject.
+
+Examples:
+
+```text
+feat(lists): allow items to be reordered
+fix(auth): reject mismatched OAuth state
+test: cover repository ownership isolation
+docs: document local migration checks
+chore: update repository guidance
+```
+
+For a breaking change, add `!` before the colon and explain the break in a `BREAKING CHANGE:` footer.
 
 ## Pull Request Checklist
 

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useId, useMemo } from "react";
 import Theme from "../../util/Theme";
 import { clampNumber } from "../../util/util";
 import InputNumber from "./forms/Input/InputNumber";
@@ -15,6 +15,7 @@ interface PaginationProps {
 }
 
 function Pagination(props: PaginationProps) {
+  const pageSizeSelectId = useId();
   let linkClassName = "page-link " + props.theme.bgText;
   let linkWrapperClassName = "page-item";
   const isRandomActive = props.isRandomActive ?? false;
@@ -108,11 +109,12 @@ function Pagination(props: PaginationProps) {
           <div className="d-flex justify-content-between w-100">
             <div className="input-group mb-3">
               <div className="input-group-prepend">
-                <label className={"input-group-text " + props.theme.bgText} htmlFor="inputGroupSelect01">
+                <label className={"input-group-text " + props.theme.bgText} htmlFor={pageSizeSelectId}>
                   Per Page
                 </label>
               </div>
               <select
+                id={pageSizeSelectId}
                 className={"custom-select " + props.theme.bgText}
                 value={isRandomActive ? 1 : props.perPage}
                 disabled={isPageSizeDisabled}

--- a/src/components/list/ListPage.tsx
+++ b/src/components/list/ListPage.tsx
@@ -2,12 +2,14 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import CustomModal from "../common/CustomModal";
 import CheckList from "../common/forms/CheckList";
 import useListPage from "./useListPage";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import IndividualListPage from "./individual-list/IndividualListPage";
 import { faEdit } from "@fortawesome/free-regular-svg-icons";
 
 function ListPage() {
+  const createListNameId = useId();
+  const updateListNameId = useId();
   const {
     theme,
     activeList,
@@ -50,11 +52,11 @@ function ListPage() {
                 }}
               >
                 <div className="form-group">
-                  <label htmlFor="listName">List Name</label>
+                  <label htmlFor={createListNameId}>List Name</label>
                   <input
                     type="text"
                     className="form-control"
-                    id="listName"
+                    id={createListNameId}
                     placeholder="Enter list name"
                     value={newListName}
                     onChange={(e) => setNewListName(e.target.value)}
@@ -85,7 +87,7 @@ function ListPage() {
                 >
                   <div className="form-group">
                     <div className="d-flex align-items-center justify-content-between">
-                      <label htmlFor="listName">Enter New Name</label>
+                      <label htmlFor={updateListNameId}>Enter New Name</label>
                       <CustomModal
                         title={`Do you want to delete ${activeList.name}?`}
                         theme={theme}
@@ -116,7 +118,7 @@ function ListPage() {
                     <input
                       type="text"
                       className="form-control mt-1"
-                      id="listName"
+                      id={updateListNameId}
                       placeholder="Enter list name"
                       value={updateListNameValue}
                       onChange={(e) => setUpdateListNameValue(e.target.value)}


### PR DESCRIPTION
## Summary

- Associate pagination and list form labels with unique React-generated control IDs so autofill and accessibility tooling resolve them correctly.
- Add a repository-wide commit and PR skill covering contribution estimates, GitHub-recognized Codex attribution, branch defaults, duplicate detection, and assignee handling.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run build` (passes with the existing chunk-size warning)
- Skill frontmatter and structure validation
- `git diff --check origin/main...HEAD`

## Notes

- `dev` was synchronized with `main` before creation; the PR diff contains only the two form fixes and the workflow skill.